### PR TITLE
feat: add session management enhancements with new methods for session ID handling and message clearing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@weni/webchat-service",
-  "version": "1.5.1-staging.0",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@weni/webchat-service",
-      "version": "1.5.1-staging.0",
+      "version": "1.5.0",
       "license": "ISC",
       "dependencies": {
         "eventemitter3": "^5.0.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@weni/webchat-service",
-  "version": "1.5.0",
+  "version": "1.5.1-staging.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@weni/webchat-service",
-      "version": "1.5.0",
+      "version": "1.5.1-staging.0",
       "license": "ISC",
       "dependencies": {
         "eventemitter3": "^5.0.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@weni/webchat-service",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@weni/webchat-service",
-      "version": "1.5.0",
+      "version": "1.6.0",
       "license": "ISC",
       "dependencies": {
         "eventemitter3": "^5.0.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@weni/webchat-service",
-  "version": "1.5.1-staging.0",
+  "version": "1.5.0",
   "description": "Framework-agnostic JavaScript library for Weni WebChat integration",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@weni/webchat-service",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "Framework-agnostic JavaScript library for Weni WebChat integration",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@weni/webchat-service",
-  "version": "1.5.0",
+  "version": "1.5.1-staging.0",
   "description": "Framework-agnostic JavaScript library for Weni WebChat integration",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",

--- a/src/core/SessionManager.js
+++ b/src/core/SessionManager.js
@@ -87,6 +87,14 @@ export default class SessionManager extends EventEmitter {
   }
 
   /**
+   * Sets session ID for future session creation
+   * @param {string} sessionId
+   */
+  setSessionId(sessionId) {
+    this.config.sessionId = sessionId;
+  }
+
+  /**
    * Updates session metadata
    * @param {Object} metadata
    */
@@ -190,10 +198,6 @@ export default class SessionManager extends EventEmitter {
       return false;
     }
 
-    if (!this._isValidSessionIdFormat(session.id)) {
-      return false;
-    }
-
     if (!session.lastMessageSentAt) {
       return true; // If no message has been sent, the session is valid
     }
@@ -202,19 +206,6 @@ export default class SessionManager extends EventEmitter {
     const elapsedSinceLastMessageSent = now - session.lastMessageSentAt;
 
     return elapsedSinceLastMessageSent < this._getContactTimeoutMs();
-  }
-
-  /**
-   * Checks if session ID has the correct format: timestamp@hostname
-   * @private
-   * @param {string} sessionId
-   * @returns {boolean}
-   */
-  _isValidSessionIdFormat(sessionId) {
-    // Valid format: {number}@{string}
-    // Example: 1544648616824@localhost
-    const pattern = /^\d+@.+$/;
-    return pattern.test(sessionId);
   }
 
   /**
@@ -407,6 +398,14 @@ export default class SessionManager extends EventEmitter {
     this._updateLastActivity();
     this._save();
     this.emit(SERVICE_EVENTS.CHAT_OPEN_CHANGED, this.session.isChatOpen);
+  }
+
+  /**
+   * Returns whether the chat widget is open
+   * @returns {boolean}
+   */
+  getIsChatOpen() {
+    return this.session ? Boolean(this.session.isChatOpen) : false;
   }
 
   /**

--- a/tests/service.test.js
+++ b/tests/service.test.js
@@ -1,204 +1,281 @@
-import WeniWebchatService from '../src/index'
+import WeniWebchatService from '../src/index';
 
 describe('WeniWebchatService', () => {
-  let service
+  let service;
 
   beforeEach(() => {
     global.localStorage = {
       getItem: jest.fn(),
       setItem: jest.fn(),
       removeItem: jest.fn(),
-      clear: jest.fn()
-    }
+      clear: jest.fn(),
+    };
 
     global.sessionStorage = {
       getItem: jest.fn(),
       setItem: jest.fn(),
       removeItem: jest.fn(),
-      clear: jest.fn()
-    }
+      clear: jest.fn(),
+    };
 
     global.WebSocket = jest.fn().mockImplementation(() => ({
       send: jest.fn(),
       close: jest.fn(),
       addEventListener: jest.fn(),
       removeEventListener: jest.fn(),
-      readyState: 1
-    }))
-  })
+      readyState: 1,
+    }));
+  });
 
   afterEach(() => {
     if (service) {
-      service.destroy()
+      service.destroy();
     }
-  })
+  });
 
   describe('Constructor', () => {
     it('should create service instance with valid config', () => {
       service = new WeniWebchatService({
         socketUrl: 'wss://test.example.com',
-        channelUuid: '12345'
-      })
+        channelUuid: '12345',
+      });
 
-      expect(service).toBeInstanceOf(WeniWebchatService)
-      expect(service.config.socketUrl).toBe('wss://test.example.com')
-      expect(service.config.channelUuid).toBe('12345')
-    })
+      expect(service).toBeInstanceOf(WeniWebchatService);
+      expect(service.config.socketUrl).toBe('wss://test.example.com');
+      expect(service.config.channelUuid).toBe('12345');
+    });
 
     it('should throw error with invalid config', () => {
       expect(() => {
-        new WeniWebchatService({})
-      }).toThrow()
-    })
+        new WeniWebchatService({});
+      }).toThrow();
+    });
 
     it('should use default config values', () => {
       service = new WeniWebchatService({
         socketUrl: 'wss://test.example.com',
-        channelUuid: '12345'
-      })
+        channelUuid: '12345',
+      });
 
-      expect(service.config.storage).toBe('local')
-      expect(service.config.connectOn).toBe('mount')
-      expect(service.config.autoReconnect).toBe(true)
-    })
-  })
+      expect(service.config.storage).toBe('local');
+      expect(service.config.connectOn).toBe('mount');
+      expect(service.config.autoReconnect).toBe(true);
+    });
+  });
 
   describe('State Management', () => {
     beforeEach(() => {
       service = new WeniWebchatService({
         socketUrl: 'wss://test.example.com',
-        channelUuid: '12345'
-      })
-    })
+        channelUuid: '12345',
+      });
+    });
 
     it('should get initial state', () => {
-      const state = service.getState()
+      const state = service.getState();
 
-      expect(state).toHaveProperty('messages')
-      expect(state).toHaveProperty('connection')
-      expect(state).toHaveProperty('context')
-      expect(state.messages).toEqual([])
-    })
+      expect(state).toHaveProperty('messages');
+      expect(state).toHaveProperty('connection');
+      expect(state).toHaveProperty('context');
+      expect(state.messages).toEqual([]);
+    });
 
     it('should set context', () => {
-      service.setContext('test-context')
-      expect(service.getContext()).toBe('test-context')
-    })
+      service.setContext('test-context');
+      expect(service.getContext()).toBe('test-context');
+    });
 
     it('should emit context changed event', () => {
-      const listener = jest.fn()
-      service.on('context:changed', listener)
+      const listener = jest.fn();
+      service.on('context:changed', listener);
 
-      service.setContext('new-context')
+      service.setContext('new-context');
 
-      expect(listener).toHaveBeenCalledWith('new-context')
-    })
-  })
+      expect(listener).toHaveBeenCalledWith('new-context');
+    });
+  });
 
   describe('Messages', () => {
     beforeEach(() => {
       service = new WeniWebchatService({
         socketUrl: 'wss://test.example.com',
-        channelUuid: '12345'
-      })
-    })
+        channelUuid: '12345',
+      });
+    });
 
     it('should get empty messages initially', () => {
-      const messages = service.getMessages()
-      expect(messages).toEqual([])
-    })
+      const messages = service.getMessages();
+      expect(messages).toEqual([]);
+    });
 
     it('should validate message text', async () => {
-      await expect(service.sendMessage('')).rejects.toThrow()
-      await expect(service.sendMessage(null)).rejects.toThrow()
-    })
-  })
+      await expect(service.sendMessage('')).rejects.toThrow();
+      await expect(service.sendMessage(null)).rejects.toThrow();
+    });
+
+    it('should clear messages while keeping session', () => {
+      // Create a session first
+      service.session.getOrCreate();
+      const sessionId = service.getSessionId();
+
+      // Add a message to state manually for testing
+      service.state.addMessage({ id: 'test-msg-1', text: 'Hello' });
+      service.state.addMessage({ id: 'test-msg-2', text: 'World' });
+
+      expect(service.getMessages()).toHaveLength(2);
+
+      // Clear messages
+      service.clearMessages();
+
+      // Messages should be cleared
+      expect(service.getMessages()).toEqual([]);
+
+      // Session should remain the same
+      expect(service.getSessionId()).toBe(sessionId);
+      expect(service.session.getSession()).not.toBeNull();
+    });
+
+    it('should emit messages:cleared event', () => {
+      service = new WeniWebchatService({
+        socketUrl: 'wss://test.example.com',
+        channelUuid: '12345',
+      });
+
+      const listener = jest.fn();
+      service.on('messages:cleared', listener);
+
+      service.clearMessages();
+
+      expect(listener).toHaveBeenCalled();
+    });
+  });
 
   describe('Session', () => {
     beforeEach(() => {
       service = new WeniWebchatService({
         socketUrl: 'wss://test.example.com',
-        channelUuid: '12345'
-      })
-    })
+        channelUuid: '12345',
+      });
+    });
 
     it('should generate session ID', () => {
-      const sessionId = service.session.getOrCreate()
-      expect(sessionId).toBeTruthy()
-      expect(typeof sessionId).toBe('string')
-    })
+      const sessionId = service.session.getOrCreate();
+      expect(sessionId).toBeTruthy();
+      expect(typeof sessionId).toBe('string');
+    });
 
     it('should clear session', () => {
-      service.session.getOrCreate()
-      service.clearSession()
-      
-      const state = service.getState()
-      expect(state.messages).toEqual([])
-    })
-  })
+      service.session.getOrCreate();
+      service.clearSession();
+
+      const state = service.getState();
+      expect(state.messages).toEqual([]);
+    });
+
+    it('should set session ID before initialization', () => {
+      service.session.setSessionId('custom-session-id');
+      expect(service.session.config.sessionId).toBe('custom-session-id');
+    });
+
+    it('should use custom session ID when creating new session', () => {
+      const customId = '1234567890@custom.host';
+      service.session.setSessionId(customId);
+      service.session.createNewSession();
+
+      expect(service.getSessionId()).toBe(customId);
+    });
+
+    it('should restart session with new ID when setSessionId is called on initialized service', async () => {
+      // Initialize the service and create a session
+      service.session.createNewSession();
+      service._initialized = true;
+      const originalSessionId = service.getSessionId();
+
+      // Set a new session ID
+      const newSessionId = '9999999999@new.host';
+      await service.setSessionId(newSessionId);
+
+      // Session should have the new ID
+      expect(service.getSessionId()).toBe(newSessionId);
+      expect(service.getSessionId()).not.toBe(originalSessionId);
+    });
+
+    it('should clear messages when setSessionId restarts session', async () => {
+      // Initialize and add messages
+      service.session.createNewSession();
+      service._initialized = true;
+      service.state.addMessage({ id: 'msg-1', text: 'Test' });
+
+      expect(service.getMessages()).toHaveLength(1);
+
+      // Set new session ID
+      await service.setSessionId('1111111111@test.host');
+
+      // Messages should be cleared
+      expect(service.getMessages()).toEqual([]);
+    });
+  });
 
   describe('Connection Status', () => {
     beforeEach(() => {
       service = new WeniWebchatService({
         socketUrl: 'wss://test.example.com',
-        channelUuid: '12345'
-      })
-    })
+        channelUuid: '12345',
+      });
+    });
 
     it('should return disconnected initially', () => {
-      expect(service.getConnectionStatus()).toBe('disconnected')
-      expect(service.isConnected()).toBe(false)
-    })
-  })
+      expect(service.getConnectionStatus()).toBe('disconnected');
+      expect(service.isConnected()).toBe(false);
+    });
+  });
 
   describe('Audio Recording', () => {
     it('should check if audio recording is supported', () => {
-      const isSupported = WeniWebchatService.isAudioRecordingSupported()
-      expect(typeof isSupported).toBe('boolean')
-    })
-  })
+      const isSupported = WeniWebchatService.isAudioRecordingSupported();
+      expect(typeof isSupported).toBe('boolean');
+    });
+  });
 
   describe('Event Emitter', () => {
     beforeEach(() => {
       service = new WeniWebchatService({
         socketUrl: 'wss://test.example.com',
-        channelUuid: '12345'
-      })
-    })
+        channelUuid: '12345',
+      });
+    });
 
     it('should register event listeners', () => {
-      const listener = jest.fn()
-      service.on('test-event', listener)
-      service.emit('test-event', 'data')
-      
-      expect(listener).toHaveBeenCalledWith('data')
-    })
+      const listener = jest.fn();
+      service.on('test-event', listener);
+      service.emit('test-event', 'data');
+
+      expect(listener).toHaveBeenCalledWith('data');
+    });
 
     it('should remove event listeners', () => {
-      const listener = jest.fn()
-      service.on('test-event', listener)
-      service.off('test-event', listener)
-      service.emit('test-event')
-      
-      expect(listener).not.toHaveBeenCalled()
-    })
-  })
+      const listener = jest.fn();
+      service.on('test-event', listener);
+      service.off('test-event', listener);
+      service.emit('test-event');
+
+      expect(listener).not.toHaveBeenCalled();
+    });
+  });
 
   describe('Destroy', () => {
     beforeEach(() => {
       service = new WeniWebchatService({
         socketUrl: 'wss://test.example.com',
-        channelUuid: '12345'
-      })
-    })
+        channelUuid: '12345',
+      });
+    });
 
     it('should clean up resources', () => {
-      service.destroy()
-      
-      expect(service._initialized).toBe(false)
-      expect(service._connected).toBe(false)
-    })
-  })
-})
+      service.destroy();
 
-
+      expect(service._initialized).toBe(false);
+      expect(service._connected).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
This PR adds several new methods to improve session management and message handling:

- Added `setSessionId(sessionId)` method to allow setting a custom session ID
- Added `clearMessages()` method to clear messages while preserving the session
- Added `getIsChatOpen()` method to check if the chat widget is open
- Removed the session ID format validation to allow more flexible session IDs
- Added tests for the new functionality

These changes provide more control over session management and improve the flexibility of the webchat service.