### PR TITLE
feat: implement order message handling and interactive message enhancements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@weni/webchat-service",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@weni/webchat-service",
-      "version": "1.6.0",
+      "version": "1.7.0",
       "license": "ISC",
       "dependencies": {
         "eventemitter3": "^5.0.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@weni/webchat-service",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "Framework-agnostic JavaScript library for Weni WebChat integration",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",

--- a/src/core/MessageProcessor.js
+++ b/src/core/MessageProcessor.js
@@ -213,6 +213,24 @@ export default class MessageProcessor extends EventEmitter {
       message.metadata = raw.metadata;
     }
 
+    const interactive = raw.message?.interactive;
+
+    if (interactive?.type === 'product_list') {
+      message.product_list = {
+        text: raw.message.text,
+        buttonText: interactive.action?.name,
+        sections: interactive.action?.sections,
+      };
+    }
+
+    if (interactive?.header) {
+      message.header = interactive.header.text;
+    }
+
+    if (interactive?.footer) {
+      message.footer = interactive.footer.text;
+    }
+
     return message;
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -33,6 +33,7 @@ import {
 import {
   buildTextMessage,
   buildMediaMessage,
+  buildOrderMessage,
   buildMessagePayload,
   buildCustomFieldMessage,
 } from './utils/messageBuilder';
@@ -292,6 +293,36 @@ export default class WeniWebchatService extends EventEmitter {
       ...message,
       persisted: true,
     });
+  }
+
+  /**
+   * Sends an order message with cart product items
+   *
+   * @param {Array} productItems Array of product items
+   * @returns {Promise<void>}
+   */
+  async sendOrder(productItems) {
+    if (
+      !productItems ||
+      !Array.isArray(productItems) ||
+      productItems.length === 0
+    ) {
+      throw new Error('Product items are required');
+    }
+
+    const message = buildOrderMessage(productItems, {
+      direction: 'outgoing',
+    });
+
+    // Add to state so the order appears in the chat
+    this.state.addMessage(message);
+    this.session.appendToConversation(message);
+
+    this.enqueueMessages([message]);
+
+    if (this._initialized) {
+      this.runQueue();
+    }
   }
 
   /**

--- a/src/modules/HistoryManager.js
+++ b/src/modules/HistoryManager.js
@@ -145,6 +145,33 @@ export default class HistoryManager extends EventEmitter {
         message.list_message = item.message.list_message;
       }
 
+      if (item.message?.type === 'interactive') {
+        const { interactive } = item.message;
+        message.text = item.message.text;
+
+        if (interactive?.header) {
+          message.header = interactive.header.text;
+        }
+
+        if (interactive?.footer) {
+          message.footer = interactive.footer.text;
+        }
+
+        if (interactive?.type === 'product_list') {
+          message.product_list = {
+            text: message.text,
+            buttonText: interactive.action?.name,
+            sections: interactive.action?.sections,
+          };
+        }
+      }
+
+      if (item.message?.type === 'order') {
+        message.order = {
+          product_items: item.message.order.product_items,
+        };
+      }
+
       return message;
     });
   }

--- a/src/utils/messageBuilder.js
+++ b/src/utils/messageBuilder.js
@@ -37,6 +37,16 @@ export function buildMessagePayload(sessionId, message, options = {}) {
         data: messageData,
       },
     );
+  } else if (message.type === 'order') {
+    return buildWebSocketMessage(
+      messageType,
+      { type: 'order', timestamp: message.timestamp, order: message.order },
+      {
+        context,
+        from,
+        data: messageData,
+      },
+    );
   } else if (message.type === 'set_custom_field') {
     return {
       type: message.type,
@@ -168,6 +178,25 @@ export function buildQuickReplyMessage(text, quickReplies, options = {}) {
     direction: options.direction || 'incoming',
     status: options.status || 'delivered',
     metadata: options.metadata || {},
+  };
+}
+
+/**
+ * Builds an order message
+ * @param {Array} productItems Array of product items with product_retailer_id, name, price, etc.
+ * @param {Object} options
+ * @returns {Object}
+ */
+export function buildOrderMessage(productItems, options = {}) {
+  return {
+    id: options.id || generateMessageId(),
+    type: 'order',
+    timestamp: (options.timestamp || Date.now()).toString(),
+    direction: options.direction || 'outgoing',
+    status: options.status || 'pending',
+    order: {
+      product_items: productItems,
+    },
   };
 }
 

--- a/tests/HistoryManager.test.js
+++ b/tests/HistoryManager.test.js
@@ -1,0 +1,408 @@
+import HistoryManager from '../src/modules/HistoryManager';
+
+describe('HistoryManager', () => {
+  let historyManager;
+
+  beforeEach(() => {
+    // Create a mock websocket with EventEmitter-like behavior
+    const mockWebSocket = {
+      on: jest.fn(),
+      off: jest.fn(),
+      emit: jest.fn(),
+    };
+
+    historyManager = new HistoryManager(mockWebSocket);
+  });
+
+  describe('processHistory', () => {
+    it('should return empty array for non-array input', () => {
+      expect(historyManager.processHistory(null)).toEqual([]);
+      expect(historyManager.processHistory(undefined)).toEqual([]);
+      expect(historyManager.processHistory('string')).toEqual([]);
+    });
+
+    it('should return empty array for empty array input', () => {
+      expect(historyManager.processHistory([])).toEqual([]);
+    });
+
+    it('should normalize a basic text message from history', () => {
+      const rawHistory = [
+        {
+          ID: 'msg-1',
+          timestamp: 1700000000,
+          direction: 'in',
+          message: { type: 'text', text: 'Hello' },
+        },
+      ];
+
+      const result = historyManager.processHistory(rawHistory);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toMatchObject({
+        id: 'msg-1',
+        type: 'text',
+        text: 'Hello',
+        direction: 'incoming',
+        sender: 'response',
+      });
+    });
+
+    it('should normalize direction "out" to "outgoing"', () => {
+      const rawHistory = [
+        {
+          ID: 'msg-1',
+          timestamp: 1700000000,
+          direction: 'out',
+          message: { type: 'text', text: 'Hello' },
+        },
+      ];
+
+      const result = historyManager.processHistory(rawHistory);
+
+      expect(result[0].direction).toBe('outgoing');
+      expect(result[0].sender).toBe('client');
+    });
+
+    describe('interactive messages', () => {
+      it('should normalize interactive message with header', () => {
+        const rawHistory = [
+          {
+            ID: 'msg-interactive-1',
+            timestamp: 1700000000,
+            direction: 'in',
+            message: {
+              type: 'interactive',
+              text: 'Choose a product',
+              interactive: {
+                header: { text: 'Welcome Header' },
+              },
+            },
+          },
+        ];
+
+        const result = historyManager.processHistory(rawHistory);
+
+        expect(result[0]).toMatchObject({
+          id: 'msg-interactive-1',
+          type: 'interactive',
+          text: 'Choose a product',
+          header: 'Welcome Header',
+        });
+      });
+
+      it('should normalize interactive message with footer', () => {
+        const rawHistory = [
+          {
+            ID: 'msg-interactive-2',
+            timestamp: 1700000000,
+            direction: 'in',
+            message: {
+              type: 'interactive',
+              text: 'Choose a product',
+              interactive: {
+                footer: { text: 'Tap to select' },
+              },
+            },
+          },
+        ];
+
+        const result = historyManager.processHistory(rawHistory);
+
+        expect(result[0]).toMatchObject({
+          text: 'Choose a product',
+          footer: 'Tap to select',
+        });
+      });
+
+      it('should normalize interactive message with product_list type', () => {
+        const rawHistory = [
+          {
+            ID: 'msg-interactive-3',
+            timestamp: 1700000000,
+            direction: 'in',
+            message: {
+              type: 'interactive',
+              text: 'Browse our products',
+              interactive: {
+                type: 'product_list',
+                action: {
+                  name: 'View Products',
+                  sections: [
+                    {
+                      title: 'Featured',
+                      product_items: [
+                        { product_retailer_id: 'prod-1' },
+                        { product_retailer_id: 'prod-2' },
+                      ],
+                    },
+                  ],
+                },
+              },
+            },
+          },
+        ];
+
+        const result = historyManager.processHistory(rawHistory);
+
+        expect(result[0].product_list).toEqual({
+          text: 'Browse our products',
+          buttonText: 'View Products',
+          sections: [
+            {
+              title: 'Featured',
+              product_items: [
+                { product_retailer_id: 'prod-1' },
+                { product_retailer_id: 'prod-2' },
+              ],
+            },
+          ],
+        });
+      });
+
+      it('should normalize interactive message with header, footer and product_list', () => {
+        const rawHistory = [
+          {
+            ID: 'msg-interactive-4',
+            timestamp: 1700000000,
+            direction: 'in',
+            message: {
+              type: 'interactive',
+              text: 'Our Catalog',
+              interactive: {
+                type: 'product_list',
+                header: { text: 'Catalog Header' },
+                footer: { text: 'Catalog Footer' },
+                action: {
+                  name: 'Browse',
+                  sections: [
+                    {
+                      title: 'All Items',
+                      product_items: [{ product_retailer_id: 'item-1' }],
+                    },
+                  ],
+                },
+              },
+            },
+          },
+        ];
+
+        const result = historyManager.processHistory(rawHistory);
+
+        expect(result[0]).toMatchObject({
+          text: 'Our Catalog',
+          header: 'Catalog Header',
+          footer: 'Catalog Footer',
+        });
+        expect(result[0].product_list).toEqual({
+          text: 'Our Catalog',
+          buttonText: 'Browse',
+          sections: [
+            {
+              title: 'All Items',
+              product_items: [{ product_retailer_id: 'item-1' }],
+            },
+          ],
+        });
+      });
+
+      it('should not set product_list for non-product_list interactive types', () => {
+        const rawHistory = [
+          {
+            ID: 'msg-interactive-5',
+            timestamp: 1700000000,
+            direction: 'in',
+            message: {
+              type: 'interactive',
+              text: 'Select an option',
+              interactive: {
+                type: 'button',
+                action: { buttons: [{ title: 'OK' }] },
+              },
+            },
+          },
+        ];
+
+        const result = historyManager.processHistory(rawHistory);
+
+        expect(result[0].product_list).toBeUndefined();
+      });
+
+      it('should not set header/footer when not present in interactive', () => {
+        const rawHistory = [
+          {
+            ID: 'msg-interactive-6',
+            timestamp: 1700000000,
+            direction: 'in',
+            message: {
+              type: 'interactive',
+              text: 'Products',
+              interactive: {
+                type: 'product_list',
+                action: { name: 'View', sections: [] },
+              },
+            },
+          },
+        ];
+
+        const result = historyManager.processHistory(rawHistory);
+
+        expect(result[0].header).toBeUndefined();
+        expect(result[0].footer).toBeUndefined();
+      });
+    });
+
+    describe('order messages', () => {
+      it('should normalize order message with product_items', () => {
+        const rawHistory = [
+          {
+            ID: 'msg-order-1',
+            timestamp: 1700000000,
+            direction: 'out',
+            message: {
+              type: 'order',
+              order: {
+                product_items: [
+                  {
+                    product_retailer_id: 'prod-1',
+                    quantity: 2,
+                    item_price: 10.0,
+                  },
+                  {
+                    product_retailer_id: 'prod-2',
+                    quantity: 1,
+                    item_price: 25.0,
+                  },
+                ],
+              },
+            },
+          },
+        ];
+
+        const result = historyManager.processHistory(rawHistory);
+
+        expect(result).toHaveLength(1);
+        expect(result[0]).toMatchObject({
+          id: 'msg-order-1',
+          type: 'order',
+          direction: 'outgoing',
+          sender: 'client',
+        });
+        expect(result[0].order).toEqual({
+          product_items: [
+            {
+              product_retailer_id: 'prod-1',
+              quantity: 2,
+              item_price: 10.0,
+            },
+            {
+              product_retailer_id: 'prod-2',
+              quantity: 1,
+              item_price: 25.0,
+            },
+          ],
+        });
+      });
+
+      it('should preserve all product item fields in order', () => {
+        const productItems = [
+          {
+            product_retailer_id: 'abc-123',
+            quantity: 3,
+            item_price: 15.99,
+            currency: 'BRL',
+          },
+        ];
+
+        const rawHistory = [
+          {
+            ID: 'msg-order-2',
+            timestamp: 1700000000,
+            direction: 'out',
+            message: {
+              type: 'order',
+              order: { product_items: productItems },
+            },
+          },
+        ];
+
+        const result = historyManager.processHistory(rawHistory);
+
+        expect(result[0].order.product_items).toEqual(productItems);
+      });
+    });
+
+    describe('mixed message types', () => {
+      it('should handle a mix of text, interactive, and order messages', () => {
+        const rawHistory = [
+          {
+            ID: 'msg-1',
+            timestamp: 1700000001,
+            direction: 'in',
+            message: { type: 'text', text: 'Hello' },
+          },
+          {
+            ID: 'msg-2',
+            timestamp: 1700000002,
+            direction: 'in',
+            message: {
+              type: 'interactive',
+              text: 'Pick a product',
+              interactive: {
+                type: 'product_list',
+                header: { text: 'Shop' },
+                action: {
+                  name: 'View',
+                  sections: [
+                    {
+                      title: 'Items',
+                      product_items: [{ product_retailer_id: 'p1' }],
+                    },
+                  ],
+                },
+              },
+            },
+          },
+          {
+            ID: 'msg-3',
+            timestamp: 1700000003,
+            direction: 'out',
+            message: {
+              type: 'order',
+              order: {
+                product_items: [{ product_retailer_id: 'p1', quantity: 1 }],
+              },
+            },
+          },
+        ];
+
+        const result = historyManager.processHistory(rawHistory);
+
+        expect(result).toHaveLength(3);
+
+        // Text message
+        expect(result[0]).toMatchObject({
+          id: 'msg-1',
+          type: 'text',
+          text: 'Hello',
+        });
+
+        // Interactive message
+        expect(result[1]).toMatchObject({
+          id: 'msg-2',
+          type: 'interactive',
+          text: 'Pick a product',
+          header: 'Shop',
+        });
+        expect(result[1].product_list).toBeDefined();
+
+        // Order message
+        expect(result[2]).toMatchObject({
+          id: 'msg-3',
+          type: 'order',
+          direction: 'outgoing',
+        });
+        expect(result[2].order.product_items).toHaveLength(1);
+      });
+    });
+  });
+});

--- a/tests/MessageProcessor.test.js
+++ b/tests/MessageProcessor.test.js
@@ -840,6 +840,145 @@ describe('MessageProcessor', () => {
 
       expect(normalized.metadata).toEqual({ custom: 'data' });
     });
+
+    it('should normalize message with interactive product_list', () => {
+      const raw = {
+        message: {
+          text: 'Check our products',
+          interactive: {
+            type: 'product_list',
+            action: {
+              name: 'View Products',
+              sections: [
+                {
+                  title: 'Category 1',
+                  product_items: [
+                    { product_retailer_id: 'prod-1' },
+                    { product_retailer_id: 'prod-2' },
+                  ],
+                },
+              ],
+            },
+          },
+        },
+      };
+
+      const normalized = processor._normalizeMessage(raw);
+
+      expect(normalized.product_list).toEqual({
+        text: 'Check our products',
+        buttonText: 'View Products',
+        sections: [
+          {
+            title: 'Category 1',
+            product_items: [
+              { product_retailer_id: 'prod-1' },
+              { product_retailer_id: 'prod-2' },
+            ],
+          },
+        ],
+      });
+    });
+
+    it('should normalize message with interactive header', () => {
+      const raw = {
+        message: {
+          text: 'Hello',
+          interactive: {
+            header: { text: 'Welcome Header' },
+          },
+        },
+      };
+
+      const normalized = processor._normalizeMessage(raw);
+
+      expect(normalized.header).toBe('Welcome Header');
+    });
+
+    it('should normalize message with interactive footer', () => {
+      const raw = {
+        message: {
+          text: 'Hello',
+          interactive: {
+            footer: { text: 'Footer text' },
+          },
+        },
+      };
+
+      const normalized = processor._normalizeMessage(raw);
+
+      expect(normalized.footer).toBe('Footer text');
+    });
+
+    it('should normalize message with interactive header, footer and product_list', () => {
+      const raw = {
+        message: {
+          text: 'Browse our catalog',
+          interactive: {
+            type: 'product_list',
+            header: { text: 'Our Catalog' },
+            footer: { text: 'Tap to view details' },
+            action: {
+              name: 'See Products',
+              sections: [
+                {
+                  title: 'Best Sellers',
+                  product_items: [{ product_retailer_id: 'best-1' }],
+                },
+              ],
+            },
+          },
+        },
+      };
+
+      const normalized = processor._normalizeMessage(raw);
+
+      expect(normalized.header).toBe('Our Catalog');
+      expect(normalized.footer).toBe('Tap to view details');
+      expect(normalized.product_list).toEqual({
+        text: 'Browse our catalog',
+        buttonText: 'See Products',
+        sections: [
+          {
+            title: 'Best Sellers',
+            product_items: [{ product_retailer_id: 'best-1' }],
+          },
+        ],
+      });
+    });
+
+    it('should not set product_list for non-product_list interactive types', () => {
+      const raw = {
+        message: {
+          text: 'Hello',
+          interactive: {
+            type: 'button',
+            action: { buttons: [{ title: 'Click me' }] },
+          },
+        },
+      };
+
+      const normalized = processor._normalizeMessage(raw);
+
+      expect(normalized.product_list).toBeUndefined();
+    });
+
+    it('should not set header/footer when interactive has no header/footer', () => {
+      const raw = {
+        message: {
+          text: 'Hello',
+          interactive: {
+            type: 'product_list',
+            action: { name: 'View', sections: [] },
+          },
+        },
+      };
+
+      const normalized = processor._normalizeMessage(raw);
+
+      expect(normalized.header).toBeUndefined();
+      expect(normalized.footer).toBeUndefined();
+    });
   });
 
   describe('processBatch', () => {

--- a/tests/messageBuilder.test.js
+++ b/tests/messageBuilder.test.js
@@ -1,0 +1,247 @@
+import {
+  buildOrderMessage,
+  buildMessagePayload,
+  buildTextMessage,
+  buildMediaMessage,
+  buildCustomFieldMessage,
+} from '../src/utils/messageBuilder';
+
+describe('messageBuilder', () => {
+  describe('buildOrderMessage', () => {
+    const productItems = [
+      { product_retailer_id: 'prod-1', quantity: 2, item_price: 10.0 },
+      { product_retailer_id: 'prod-2', quantity: 1, item_price: 25.0 },
+    ];
+
+    it('should build an order message with required fields', () => {
+      const message = buildOrderMessage(productItems);
+
+      expect(message).toMatchObject({
+        type: 'order',
+        direction: 'outgoing',
+        status: 'pending',
+        order: {
+          product_items: productItems,
+        },
+      });
+      expect(message.id).toBeDefined();
+      expect(message.timestamp).toBeDefined();
+    });
+
+    it('should generate a unique id', () => {
+      const message1 = buildOrderMessage(productItems);
+      const message2 = buildOrderMessage(productItems);
+
+      expect(message1.id).not.toBe(message2.id);
+    });
+
+    it('should use provided id from options', () => {
+      const message = buildOrderMessage(productItems, { id: 'custom-id' });
+
+      expect(message.id).toBe('custom-id');
+    });
+
+    it('should use provided timestamp from options', () => {
+      const timestamp = 1700000000000;
+      const message = buildOrderMessage(productItems, { timestamp });
+
+      expect(message.timestamp).toBe(timestamp.toString());
+    });
+
+    it('should convert timestamp to string', () => {
+      const message = buildOrderMessage(productItems);
+
+      expect(typeof message.timestamp).toBe('string');
+    });
+
+    it('should use provided direction from options', () => {
+      const message = buildOrderMessage(productItems, {
+        direction: 'incoming',
+      });
+
+      expect(message.direction).toBe('incoming');
+    });
+
+    it('should use provided status from options', () => {
+      const message = buildOrderMessage(productItems, {
+        status: 'delivered',
+      });
+
+      expect(message.status).toBe('delivered');
+    });
+
+    it('should preserve all product item properties', () => {
+      const items = [
+        {
+          product_retailer_id: 'abc-123',
+          quantity: 3,
+          item_price: 15.99,
+          currency: 'BRL',
+        },
+      ];
+
+      const message = buildOrderMessage(items);
+
+      expect(message.order.product_items).toEqual(items);
+    });
+  });
+
+  describe('buildMessagePayload', () => {
+    const sessionId = 'test-session-123';
+
+    describe('order message type', () => {
+      it('should build payload for order message', () => {
+        const orderMessage = {
+          type: 'order',
+          timestamp: '1700000000000',
+          order: {
+            product_items: [{ product_retailer_id: 'prod-1', quantity: 1 }],
+          },
+        };
+
+        const payload = buildMessagePayload(sessionId, orderMessage);
+
+        expect(payload).toMatchObject({
+          type: 'message',
+          message: {
+            type: 'order',
+            timestamp: '1700000000000',
+            order: {
+              product_items: [{ product_retailer_id: 'prod-1', quantity: 1 }],
+            },
+          },
+          from: sessionId,
+          context: '',
+        });
+      });
+
+      it('should include context when provided', () => {
+        const orderMessage = {
+          type: 'order',
+          timestamp: '1700000000000',
+          order: { product_items: [{ product_retailer_id: 'prod-1' }] },
+        };
+
+        const payload = buildMessagePayload(sessionId, orderMessage, {
+          context: 'test-context',
+        });
+
+        expect(payload.context).toBe('test-context');
+      });
+
+      it('should use message_with_fields type when custom fields present', () => {
+        const orderMessage = {
+          type: 'order',
+          timestamp: '1700000000000',
+          order: { product_items: [{ product_retailer_id: 'prod-1' }] },
+          __customFields: { field1: 'value1' },
+        };
+
+        const payload = buildMessagePayload(sessionId, orderMessage);
+
+        expect(payload.type).toBe('message_with_fields');
+        expect(payload.data).toEqual({ field1: 'value1' });
+      });
+    });
+
+    describe('text message type', () => {
+      it('should build payload for text message', () => {
+        const textMessage = { type: 'text', text: 'Hello' };
+
+        const payload = buildMessagePayload(sessionId, textMessage);
+
+        expect(payload).toMatchObject({
+          type: 'message',
+          message: { type: 'text', text: 'Hello' },
+          from: sessionId,
+        });
+      });
+    });
+
+    describe('media message type', () => {
+      it('should build payload for image message', () => {
+        const imageMessage = {
+          type: 'image',
+          media: { url: 'http://example.com/image.jpg' },
+        };
+
+        const payload = buildMessagePayload(sessionId, imageMessage);
+
+        expect(payload).toMatchObject({
+          type: 'message',
+          message: {
+            type: 'image',
+            media: { url: 'http://example.com/image.jpg' },
+          },
+        });
+      });
+    });
+
+    describe('set_custom_field message type', () => {
+      it('should build payload for set_custom_field message', () => {
+        const customFieldMessage = {
+          type: 'set_custom_field',
+          data: { key: 'name', value: 'John' },
+        };
+
+        const payload = buildMessagePayload(sessionId, customFieldMessage);
+
+        expect(payload).toEqual({
+          type: 'set_custom_field',
+          data: { key: 'name', value: 'John' },
+        });
+      });
+    });
+
+    describe('invalid message type', () => {
+      it('should throw error for unsupported message type', () => {
+        const invalidMessage = { type: 'unknown_type' };
+
+        expect(() => buildMessagePayload(sessionId, invalidMessage)).toThrow(
+          'Invalid message type',
+        );
+      });
+    });
+  });
+
+  describe('buildTextMessage', () => {
+    it('should build a text message with defaults', () => {
+      const message = buildTextMessage('Hello');
+
+      expect(message).toMatchObject({
+        type: 'text',
+        text: 'Hello',
+        direction: 'outgoing',
+        status: 'pending',
+      });
+      expect(message.id).toBeDefined();
+      expect(message.timestamp).toBeDefined();
+    });
+  });
+
+  describe('buildMediaMessage', () => {
+    it('should build a media message with defaults', () => {
+      const media = { url: 'http://example.com/image.jpg' };
+      const message = buildMediaMessage('image', media);
+
+      expect(message).toMatchObject({
+        type: 'image',
+        media,
+        direction: 'outgoing',
+        status: 'pending',
+      });
+    });
+  });
+
+  describe('buildCustomFieldMessage', () => {
+    it('should build a custom field message', () => {
+      const message = buildCustomFieldMessage('name', 'John');
+
+      expect(message).toEqual({
+        type: 'set_custom_field',
+        data: { key: 'name', value: 'John' },
+        status: 'pending',
+      });
+    });
+  });
+});


### PR DESCRIPTION
### TL;DR

Added support for interactive product lists and order messages in the webchat service.

### What changed?

- Enhanced `MessageProcessor.js` to handle interactive product lists, including header and footer text
- Added a new `sendOrder()` method to the main service class to send order messages with product items
- Updated `HistoryManager.js` to properly process and display interactive messages and order messages
- Created a new `buildOrderMessage()` utility function to construct order message objects

### Why make this change?

This change adds support for e-commerce functionality in the webchat service, allowing businesses to display product catalogs and process orders directly within the chat interface. This enhances the webchat's capabilities for retail and e-commerce use cases.