### PR TITLE
feat: add voice mode support — token provisioning and voice-enabled signaling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@weni/webchat-service",
-  "version": "1.8.0",
+  "version": "1.9.0-staging.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@weni/webchat-service",
-      "version": "1.8.0",
+      "version": "1.9.0-staging.0",
       "license": "ISC",
       "dependencies": {
         "eventemitter3": "^5.0.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@weni/webchat-service",
-  "version": "1.8.0",
+  "version": "1.9.0-staging.0",
   "description": "Framework-agnostic JavaScript library for Weni WebChat integration",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",

--- a/src/core/WebSocketManager.js
+++ b/src/core/WebSocketManager.js
@@ -213,13 +213,17 @@ export default class WebSocketManager extends EventEmitter {
     });
   }
 
-  async _handleReadyForMessage() {
+  async _handleReadyForMessage(data = {}) {
     this.status = 'connected';
 
     this.reconnectAttempts = 0;
 
     if (this.retryStrategy) {
       this.retryStrategy.reset();
+    }
+
+    if (data.data?.voice_enabled) {
+      this.emit(SERVICE_EVENTS.VOICE_ENABLED);
     }
 
     this.emit(SERVICE_EVENTS.CONNECTION_STATUS_CHANGED, this.status);
@@ -373,7 +377,7 @@ export default class WebSocketManager extends EventEmitter {
       }
 
       if (data.type === 'ready_for_message') {
-        this._handleReadyForMessage();
+        this._handleReadyForMessage(data);
         return;
       }
 

--- a/src/core/WebSocketManager.js
+++ b/src/core/WebSocketManager.js
@@ -162,6 +162,57 @@ export default class WebSocketManager extends EventEmitter {
     });
   }
 
+  /**
+   * Requests single-use voice tokens from the server.
+   * Resolves with { sttToken, ttsToken } or rejects on error/timeout.
+   *
+   * @param {number} [timeoutMs=10000]
+   * @returns {Promise<{ sttToken: string, ttsToken: string }>}
+   */
+  requestVoiceTokens(timeoutMs = 10000) {
+    return new Promise((resolve, reject) => {
+      let settled = false;
+
+      const timer = setTimeout(() => {
+        if (settled) return;
+        settled = true;
+        cleanup();
+        reject(new Error('Voice tokens request timed out'));
+      }, timeoutMs);
+
+      const onReceived = (data) => {
+        if (settled) return;
+        settled = true;
+        cleanup();
+        const tokens = data.data || data;
+        resolve({ sttToken: tokens.stt_token, ttsToken: tokens.tts_token });
+      };
+
+      const onError = (data) => {
+        if (settled) return;
+        settled = true;
+        cleanup();
+        reject(new Error(data.error || 'Failed to get voice tokens'));
+      };
+
+      const cleanup = () => {
+        clearTimeout(timer);
+        this.off(SERVICE_EVENTS.VOICE_TOKENS_RECEIVED, onReceived);
+        this.off(SERVICE_EVENTS.VOICE_TOKENS_ERROR, onError);
+      };
+
+      this.once(SERVICE_EVENTS.VOICE_TOKENS_RECEIVED, onReceived);
+      this.once(SERVICE_EVENTS.VOICE_TOKENS_ERROR, onError);
+
+      this.send({ type: 'request_voice_tokens' }).catch((err) => {
+        if (settled) return;
+        settled = true;
+        cleanup();
+        reject(err);
+      });
+    });
+  }
+
   async _handleReadyForMessage() {
     this.status = 'connected';
 
@@ -333,6 +384,16 @@ export default class WebSocketManager extends EventEmitter {
 
       if (data.type === 'project_language') {
         this.emit(SERVICE_EVENTS.LANGUAGE_CHANGED, data.data.language);
+        return;
+      }
+
+      if (data.type === 'voice_tokens') {
+        this.emit(SERVICE_EVENTS.VOICE_TOKENS_RECEIVED, data);
+        return;
+      }
+
+      if (data.type === 'voice_tokens_error') {
+        this.emit(SERVICE_EVENTS.VOICE_TOKENS_ERROR, data);
         return;
       }
 

--- a/src/index.js
+++ b/src/index.js
@@ -854,6 +854,17 @@ export default class WeniWebchatService extends EventEmitter {
   }
 
   /**
+   * Requests single-use ElevenLabs voice tokens from the Weni backend.
+   * The server responds with a `voice_tokens` message containing the tokens.
+   *
+   * @param {number} [timeoutMs=10000] Maximum wait time in milliseconds
+   * @returns {Promise<{ sttToken: string, ttsToken: string }>}
+   */
+  requestVoiceTokens(timeoutMs = 10000) {
+    return this.websocket.requestVoiceTokens(timeoutMs);
+  }
+
+  /**
    * Destroys service instance
    */
   destroy() {
@@ -941,6 +952,14 @@ export default class WeniWebchatService extends EventEmitter {
 
     this.websocket.on(SERVICE_EVENTS.LANGUAGE_CHANGED, (language) => {
       this.emit(SERVICE_EVENTS.LANGUAGE_CHANGED, language);
+    });
+
+    this.websocket.on(SERVICE_EVENTS.VOICE_TOKENS_RECEIVED, (data) => {
+      this.emit(SERVICE_EVENTS.VOICE_TOKENS_RECEIVED, data);
+    });
+
+    this.websocket.on(SERVICE_EVENTS.VOICE_TOKENS_ERROR, (data) => {
+      this.emit(SERVICE_EVENTS.VOICE_TOKENS_ERROR, data);
     });
 
     // Message processor events

--- a/src/index.js
+++ b/src/index.js
@@ -954,6 +954,10 @@ export default class WeniWebchatService extends EventEmitter {
       this.emit(SERVICE_EVENTS.LANGUAGE_CHANGED, language);
     });
 
+    this.websocket.on(SERVICE_EVENTS.VOICE_ENABLED, () => {
+      this.emit(SERVICE_EVENTS.VOICE_ENABLED);
+    });
+
     this.websocket.on(SERVICE_EVENTS.VOICE_TOKENS_RECEIVED, (data) => {
       this.emit(SERVICE_EVENTS.VOICE_TOKENS_RECEIVED, data);
     });

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -46,6 +46,8 @@ export const WS_MESSAGE_TYPES = {
   ERROR: 'error',
   WARNING: 'warning',
   FORBIDDEN: 'forbidden',
+  REQUEST_VOICE_TOKENS: 'request_voice_tokens',
+  VOICE_TOKENS: 'voice_tokens',
 };
 
 export const STORAGE_KEYS = {
@@ -242,6 +244,10 @@ export const SERVICE_EVENTS = {
   HISTORY_REQUESTED: 'history:requested',
   HISTORY_MERGED: 'history:merged',
   HISTORY_CACHE_CLEARED: 'history:cache:cleared',
+
+  // Voice tokens
+  VOICE_TOKENS_RECEIVED: 'voice:tokens:received',
+  VOICE_TOKENS_ERROR: 'voice:tokens:error',
 
   // WebSocket
   WS_REGISTERED: 'registered',

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -245,7 +245,8 @@ export const SERVICE_EVENTS = {
   HISTORY_MERGED: 'history:merged',
   HISTORY_CACHE_CLEARED: 'history:cache:cleared',
 
-  // Voice tokens
+  // Voice
+  VOICE_ENABLED: 'voice:enabled',
   VOICE_TOKENS_RECEIVED: 'voice:tokens:received',
   VOICE_TOKENS_ERROR: 'voice:tokens:error',
 

--- a/tests/service.test.js
+++ b/tests/service.test.js
@@ -343,6 +343,86 @@ describe('WeniWebchatService', () => {
     });
   });
 
+  describe('voice:enabled on ready_for_message', () => {
+    let mockSocket;
+
+    beforeEach(() => {
+      mockSocket = {
+        send: jest.fn(),
+        close: jest.fn(),
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+        readyState: WebSocket.OPEN,
+      };
+
+      global.WebSocket = jest.fn().mockImplementation(() => mockSocket);
+
+      service = new WeniWebchatService({
+        socketUrl: 'wss://test.example.com',
+        channelUuid: '12345',
+      });
+
+      service.websocket.socket = mockSocket;
+    });
+
+    it('should emit voice:enabled when server sends voice_enabled: true', () => {
+      const listener = jest.fn();
+      service.on('voice:enabled', listener);
+
+      service.websocket._handleMessage({
+        data: JSON.stringify({
+          type: 'ready_for_message',
+          data: { voice_enabled: true, history: [] },
+        }),
+      });
+
+      expect(listener).toHaveBeenCalled();
+    });
+
+    it('should not emit voice:enabled when server sends voice_enabled: false', () => {
+      const listener = jest.fn();
+      service.on('voice:enabled', listener);
+
+      service.websocket._handleMessage({
+        data: JSON.stringify({
+          type: 'ready_for_message',
+          data: { voice_enabled: false, history: [] },
+        }),
+      });
+
+      expect(listener).not.toHaveBeenCalled();
+    });
+
+    it('should not emit voice:enabled when data is missing', () => {
+      const listener = jest.fn();
+      service.on('voice:enabled', listener);
+
+      service.websocket._handleMessage({
+        data: JSON.stringify({
+          type: 'ready_for_message',
+        }),
+      });
+
+      expect(listener).not.toHaveBeenCalled();
+    });
+
+    it('should emit voice:enabled before connected', () => {
+      const events = [];
+      service.on('voice:enabled', () => events.push('voice:enabled'));
+      service.on('connected', () => events.push('connected'));
+
+      service.websocket._handleMessage({
+        data: JSON.stringify({
+          type: 'ready_for_message',
+          data: { voice_enabled: true },
+        }),
+      });
+
+      expect(events[0]).toBe('voice:enabled');
+      expect(events).toContain('connected');
+    });
+  });
+
   describe('requestVoiceTokens', () => {
     let mockSocket;
 

--- a/tests/service.test.js
+++ b/tests/service.test.js
@@ -343,6 +343,99 @@ describe('WeniWebchatService', () => {
     });
   });
 
+  describe('requestVoiceTokens', () => {
+    let mockSocket;
+
+    beforeEach(() => {
+      mockSocket = {
+        send: jest.fn(),
+        close: jest.fn(),
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+        readyState: WebSocket.OPEN,
+      };
+
+      global.WebSocket = jest.fn().mockImplementation(() => mockSocket);
+
+      service = new WeniWebchatService({
+        socketUrl: 'wss://test.example.com',
+        channelUuid: '12345',
+      });
+
+      service.websocket.socket = mockSocket;
+      service.websocket.status = 'connected';
+    });
+
+    it('should resolve with sttToken and ttsToken when server responds', async () => {
+      const promise = service.requestVoiceTokens();
+
+      service.websocket.emit('voice:tokens:received', {
+        type: 'voice_tokens',
+        data: {
+          stt_token: 'stt-abc-123',
+          tts_token: 'tts-xyz-789',
+        },
+      });
+
+      await expect(promise).resolves.toEqual({
+        sttToken: 'stt-abc-123',
+        ttsToken: 'tts-xyz-789',
+      });
+    });
+
+    it('should reject when server responds with an error', async () => {
+      const promise = service.requestVoiceTokens();
+
+      service.websocket.emit('voice:tokens:error', {
+        type: 'voice_tokens_error',
+        error: 'Channel not configured for voice',
+      });
+
+      await expect(promise).rejects.toThrow('Channel not configured for voice');
+    });
+
+    it('should reject after timeout if no response is received', async () => {
+      jest.useFakeTimers();
+
+      const promise = service.requestVoiceTokens(5000);
+
+      jest.advanceTimersByTime(5001);
+
+      await expect(promise).rejects.toThrow('Voice tokens request timed out');
+
+      jest.useRealTimers();
+    });
+
+    it('should emit voice:tokens:received event on service when received', async () => {
+      const listener = jest.fn();
+      service.on('voice:tokens:received', listener);
+
+      service.websocket.emit('voice:tokens:received', {
+        type: 'voice_tokens',
+        data: {
+          stt_token: 'stt-token',
+          tts_token: 'tts-token',
+        },
+      });
+
+      expect(listener).toHaveBeenCalledWith({
+        type: 'voice_tokens',
+        data: {
+          stt_token: 'stt-token',
+          tts_token: 'tts-token',
+        },
+      });
+    });
+
+    it('should send request_voice_tokens message through WebSocket', () => {
+      service.requestVoiceTokens();
+
+      expect(mockSocket.send).toHaveBeenCalledWith(
+        JSON.stringify({ type: 'request_voice_tokens' }),
+      );
+    });
+  });
+
   describe('Destroy', () => {
     beforeEach(() => {
       service = new WeniWebchatService({


### PR DESCRIPTION
## Summary

Adds voice mode infrastructure to the WebSocket service layer, enabling the React client to request ElevenLabs single-use tokens and to know whether voice mode is available on the current channel.

- **`voice:enabled` signaling** — When the server sends `voice_enabled: true` inside the `ready_for_message` payload, the service emits a `voice:enabled` event, letting the client show voice UI immediately on connection without extra round-trips.
- **`requestVoiceTokens()` API** — New promise-based method that sends a `request_voice_tokens` message to the server, listens for `voice_tokens` / `voice_tokens_error` responses, and resolves with `{ sttToken, ttsToken }`. Includes a configurable timeout (default 10 s).
- **New event constants** — `VOICE_ENABLED`, `VOICE_TOKENS_RECEIVED`, `VOICE_TOKENS_ERROR` added to `SERVICE_EVENTS` and wired through the `WebSocketManager` → `WeniWebchatService` event chain.
- **Comprehensive tests** — 9 new test cases covering: `voice:enabled` emission (true/false/missing), event ordering, token resolution, error rejection, timeout, event forwarding, and WebSocket message format.

## Related PRs

| Repo | PR | Role |
|------|----|------|
| **weni-webchat-socket** | [#141](https://github.com/weni-ai/weni-webchat-socket/pull/141) | Backend — fetches ElevenLabs API key from Flows, caches in Redis, provisions single-use tokens, sends `voice_enabled` flag on registration |
| **webchat-react** | [#56](https://github.com/weni-ai/webchat-react/pull/56) | Frontend — full voice mode UI, STT/TTS services, server-driven enablement via `voice:enabled` event from this service |

## Backward compatibility

- The new events are purely additive. Older React clients that don't listen for `voice:enabled` or `voice:tokens:*` will simply never receive them — no behavioral change.
- The `ready_for_message` handler still processes all existing fields; `voice_enabled` is only inspected when present.

## Test plan

- [x] `voice:enabled` emitted only when `voice_enabled: true` is present in `ready_for_message`
- [x] `voice:enabled` fires before `connected` event
- [x] `requestVoiceTokens` resolves with correct token structure
- [x] `requestVoiceTokens` rejects on server error response
- [x] `requestVoiceTokens` rejects after timeout
- [x] WebSocket message format matches server expectation (`{ type: 'request_voice_tokens' }`)