### PR TITLE
[EXPERI-3295] ✨ Add to Cart Interface

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -61,7 +61,6 @@
       "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.3",
@@ -3144,7 +3143,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3503,7 +3501,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.9",
         "caniuse-lite": "^1.0.30001746",
@@ -4090,7 +4087,6 @@
       "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4151,7 +4147,6 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -6523,7 +6518,6 @@
       "integrity": "sha512-v6UNi1+3hSlVvv8fSaoUbggEM5VErKmmpGA7Pl3HF8V6uKY7rvClBOJlH6yNwQtfTueNkGVpOv/mtWL9L4bgRA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -6788,7 +6782,6 @@
       "integrity": "sha512-CLEVl+MnPAiKh5pl4dEWSyMTpuflgNQiLGhMv8ezD5W/qP8AKvmYpCOKRRNOh7oRKnauBZ4SyeYkMS+1VSyKwQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },

--- a/src/core/WebSocketManager.js
+++ b/src/core/WebSocketManager.js
@@ -42,6 +42,7 @@ export default class WebSocketManager extends EventEmitter {
     this.isRegistered = false;
     this.registrationData = null;
     this.retryStrategy = this.config.retryStrategy;
+    this.pendingAddToCartRequests = new Map();
   }
 
   /**
@@ -213,6 +214,84 @@ export default class WebSocketManager extends EventEmitter {
         if (settled) return;
         settled = true;
         cleanup();
+        reject(err);
+      });
+    });
+  }
+
+  /**
+   * Requests the backend to add an item to the VTEX cart.
+   * Supports concurrent requests by correlating responses using item id.
+   *
+   * @param {Object} props
+   * @param {string} props.VTEXAccountName
+   * @param {string} props.orderFormId
+   * @param {string} props.seller
+   * @param {string} props.id
+   * @param {number} [timeoutMs=30000]
+   * @returns {Promise<{ id: string }>}
+   */
+  addProductToCart(props, timeoutMs = 30000) {
+    return new Promise((resolve, reject) => {
+      const { VTEXAccountName, orderFormId, seller, id: itemId } = props || {};
+
+      if (!VTEXAccountName || typeof VTEXAccountName !== 'string') {
+        reject(new Error('VTEXAccountName is required'));
+        return;
+      }
+
+      if (!orderFormId || typeof orderFormId !== 'string') {
+        reject(new Error('orderFormId is required'));
+        return;
+      }
+
+      if (!seller || typeof seller !== 'string') {
+        reject(new Error('seller is required'));
+        return;
+      }
+
+      if (!itemId || typeof itemId !== 'string') {
+        reject(new Error('id is required'));
+        return;
+      }
+
+      if (this.pendingAddToCartRequests.has(itemId)) {
+        reject(
+          new Error(
+            `An add-to-cart request is already pending for item id "${itemId}"`,
+          ),
+        );
+        return;
+      }
+
+      const timer = setTimeout(() => {
+        this.pendingAddToCartRequests.delete(itemId);
+        reject(
+          new Error(`Add to cart request timed out for item id "${itemId}"`),
+        );
+      }, timeoutMs);
+
+      this.pendingAddToCartRequests.set(itemId, {
+        resolve,
+        reject,
+        timer,
+      });
+
+      this.send({
+        type: 'add_to_cart',
+        data: {
+          vtex_account: VTEXAccountName,
+          order_form_id: orderFormId,
+          item: {
+            seller,
+            id: itemId,
+          },
+        },
+      }).catch((err) => {
+        const pending = this.pendingAddToCartRequests.get(itemId);
+        if (!pending) return;
+        clearTimeout(pending.timer);
+        this.pendingAddToCartRequests.delete(itemId);
         reject(err);
       });
     });
@@ -408,6 +487,20 @@ export default class WebSocketManager extends EventEmitter {
 
       if (data.type === 'voice_tokens_error') {
         this.emit(SERVICE_EVENTS.VOICE_TOKENS_ERROR, data);
+        return;
+      }
+
+      if (data.type === 'cart_updated') {
+        const itemId = data?.data?.item_id;
+
+        if (itemId && this.pendingAddToCartRequests.has(itemId)) {
+          const pending = this.pendingAddToCartRequests.get(itemId);
+          clearTimeout(pending.timer);
+          this.pendingAddToCartRequests.delete(itemId);
+          pending.resolve({ id: itemId });
+        }
+
+        this.emit(SERVICE_EVENTS.CART_UPDATED, data);
         return;
       }
 

--- a/src/index.js
+++ b/src/index.js
@@ -913,6 +913,21 @@ export default class WeniWebchatService extends EventEmitter {
   }
 
   /**
+   * Adds a product to cart through WebSocket and waits for confirmation.
+   *
+   * @param {Object} props
+   * @param {string} props.VTEXAccountName
+   * @param {string} props.orderFormId
+   * @param {string} props.seller
+   * @param {string} props.id
+   * @param {number} [timeoutMs=30000] Maximum wait time in milliseconds
+   * @returns {Promise<{ id: string }>}
+   */
+  addProductToCart(props, timeoutMs = 30000) {
+    return this.websocket.addProductToCart(props, timeoutMs);
+  }
+
+  /**
    * Destroys service instance
    */
   destroy() {
@@ -1026,6 +1041,10 @@ export default class WeniWebchatService extends EventEmitter {
 
     this.websocket.on(SERVICE_EVENTS.VOICE_TOKENS_ERROR, (data) => {
       this.emit(SERVICE_EVENTS.VOICE_TOKENS_ERROR, data);
+    });
+
+    this.websocket.on(SERVICE_EVENTS.CART_UPDATED, (data) => {
+      this.emit(SERVICE_EVENTS.CART_UPDATED, data);
     });
 
     // Message processor events

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -316,6 +316,13 @@ export interface FileConfig {
   acceptAttribute: string
 }
 
+export interface AddProductToCartProps {
+  VTEXAccountName: string
+  orderFormId: string
+  seller: string
+  id: string
+}
+
 /**
  * Main service class
  */
@@ -330,6 +337,10 @@ export default class WeniWebchatService {
 
   // Messages
   sendMessage(text: string, options?: any): Promise<void>
+  addProductToCart(
+    props: AddProductToCartProps,
+    timeoutMs?: number
+  ): Promise<{ id: string }>
   sendAttachment(file: File): Promise<void>
   sendAudio(audioData: any): Promise<void>
 

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -252,6 +252,9 @@ export const SERVICE_EVENTS = {
   VOICE_TOKENS_RECEIVED: 'voice:tokens:received',
   VOICE_TOKENS_ERROR: 'voice:tokens:error',
 
+  // Cart
+  CART_UPDATED: 'cart:updated',
+
   // WebSocket
   WS_REGISTERED: 'registered',
   WS_FORBIDDEN: 'websocket:forbidden',

--- a/tests/service.test.js
+++ b/tests/service.test.js
@@ -516,6 +516,159 @@ describe('WeniWebchatService', () => {
     });
   });
 
+  describe('addProductToCart', () => {
+    let mockSocket;
+    const validProps = {
+      VTEXAccountName: 'account-name',
+      orderFormId: '1234567890',
+      seller: 'seller_123',
+      id: 'product_456',
+    };
+
+    beforeEach(() => {
+      mockSocket = {
+        send: jest.fn(),
+        close: jest.fn(),
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+        readyState: WebSocket.OPEN,
+      };
+
+      global.WebSocket = jest.fn().mockImplementation(() => mockSocket);
+
+      service = new WeniWebchatService({
+        socketUrl: 'wss://test.example.com',
+        channelUuid: '12345',
+      });
+
+      service.websocket.socket = mockSocket;
+      service.websocket.status = 'connected';
+    });
+
+    it('should send add_to_cart payload through WebSocket', () => {
+      service.addProductToCart(validProps);
+
+      expect(mockSocket.send).toHaveBeenCalledWith(
+        JSON.stringify({
+          type: 'add_to_cart',
+          data: {
+            vtex_account: 'account-name',
+            order_form_id: '1234567890',
+            item: {
+              seller: 'seller_123',
+              id: 'product_456',
+            },
+          },
+        }),
+      );
+    });
+
+    it('should resolve when cart_updated arrives with matching item_id', async () => {
+      const promise = service.addProductToCart(validProps);
+
+      service.websocket._handleMessage({
+        data: JSON.stringify({
+          type: 'cart_updated',
+          data: { item_id: 'product_456' },
+        }),
+      });
+
+      await expect(promise).resolves.toEqual({ id: 'product_456' });
+    });
+
+    it('should not resolve for a different item_id', async () => {
+      jest.useFakeTimers();
+
+      const promise = service.addProductToCart(validProps, 50);
+
+      service.websocket._handleMessage({
+        data: JSON.stringify({
+          type: 'cart_updated',
+          data: { item_id: 'another-item' },
+        }),
+      });
+
+      jest.advanceTimersByTime(51);
+
+      await expect(promise).rejects.toThrow(
+        'Add to cart request timed out for item id "product_456"',
+      );
+
+      jest.useRealTimers();
+    });
+
+    it('should resolve concurrent requests by matching each item_id', async () => {
+      const p1 = service.addProductToCart({
+        ...validProps,
+        id: 'product_1',
+      });
+      const p2 = service.addProductToCart({
+        ...validProps,
+        id: 'product_2',
+      });
+
+      service.websocket._handleMessage({
+        data: JSON.stringify({
+          type: 'cart_updated',
+          data: { item_id: 'product_2' },
+        }),
+      });
+      service.websocket._handleMessage({
+        data: JSON.stringify({
+          type: 'cart_updated',
+          data: { item_id: 'product_1' },
+        }),
+      });
+
+      await expect(p2).resolves.toEqual({ id: 'product_2' });
+      await expect(p1).resolves.toEqual({ id: 'product_1' });
+    });
+
+    it('should reject after 30 seconds when no response is received', async () => {
+      jest.useFakeTimers();
+
+      const promise = service.addProductToCart(validProps);
+
+      jest.advanceTimersByTime(30001);
+
+      await expect(promise).rejects.toThrow(
+        'Add to cart request timed out for item id "product_456"',
+      );
+
+      jest.useRealTimers();
+    });
+
+    it('should reject when input is invalid', async () => {
+      await expect(service.addProductToCart(null)).rejects.toThrow(
+        'VTEXAccountName is required',
+      );
+      await expect(
+        service.addProductToCart({
+          ...validProps,
+          VTEXAccountName: '',
+        }),
+      ).rejects.toThrow('VTEXAccountName is required');
+      await expect(
+        service.addProductToCart({
+          ...validProps,
+          orderFormId: '',
+        }),
+      ).rejects.toThrow('orderFormId is required');
+      await expect(
+        service.addProductToCart({
+          ...validProps,
+          seller: '',
+        }),
+      ).rejects.toThrow('seller is required');
+      await expect(
+        service.addProductToCart({
+          ...validProps,
+          id: '',
+        }),
+      ).rejects.toThrow('id is required');
+    });
+  });
+
   describe('Destroy', () => {
     beforeEach(() => {
       service = new WeniWebchatService({


### PR DESCRIPTION
## Description

### Type of Change

<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->

* * [ ] Bugfix
* * [x] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [x] Tests
* * [ ] Other

### Motivation and Context

PDP/cart integrations need to ask the backend to add a VTEX cart item over the WebSocket and know when the operation was acknowledged. Multiple add operations can run concurrently, so confirmations must be correlated with the item that was sent. A wait limit is also required so pending Promises do not hang indefinitely.

### Summary of Changes

- **`WebSocketManager`**: adds `addProductToCart(props, timeoutMs = 30000)`, validating `VTEXAccountName`, `orderFormId`, `seller`, and `id`, sending `{ type: 'add_to_cart', data: { vtex_account, order_form_id, item: { seller, id } } }`, tracking pending requests in a `Map` keyed by `id`, rejecting duplicate requests for the same `id` while one is pending, and enforcing a timeout with a clear error message.
- **`_handleMessage`**: handles `type: 'cart_updated'` using `data.item_id` to resolve the matching Promise with `{ id: itemId }`, clear the timer and map entry, and emit `SERVICE_EVENTS.CART_UPDATED` with the raw payload.
- **`SERVICE_EVENTS`**: new `CART_UPDATED` event (`cart:updated`).
- **`WeniWebchatService`**: public `addProductToCart` delegating to `WebSocketManager`; forwards `cart:updated` to service consumers.
- **`src/types/index.d.ts`**: `AddProductToCartProps` interface and typed `addProductToCart` signature.
- **`tests/service.test.js`**: payload send, resolve on matching `item_id`, no resolve on mismatched `item_id`, concurrent requests, 30s timeout, and invalid input validation.