### PR TITLE
[EXPERI-3308] ✨ Conversation Status

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -37,6 +37,7 @@ import {
   buildMessagePayload,
   buildCustomFieldMessage,
   buildStartersRequest,
+  buildConversationStatusMessage,
 } from './utils/messageBuilder';
 
 /**
@@ -370,6 +371,37 @@ export default class WeniWebchatService extends EventEmitter {
     this.state.addMessage(message);
     this.session.appendToConversation(message);
     this.session.setLastMessageSentAt(Date.now());
+  }
+
+  /**
+   * Adds a local-only conversation status row (stored in session; not sent over WebSocket).
+   * Survives reconnect/history merge like other persisted local rows.
+   * Host apps should render messages with type conversation_status using text and statusType
+   * (semantic strings such as success, info, or any custom value).
+   *
+   * @param {string} text Status text
+   * @param {string} statusType Semantic type for styling (e.g. success, info)
+   * @param {Object} [options] Optional id, timestamp, direction, metadata
+   * @returns {Object} The message object that was appended
+   */
+  addConversationStatus(text, statusType, options = {}) {
+    if (!text || typeof text !== 'string' || !text.trim()) {
+      throw new Error('Status text is required');
+    }
+    if (!statusType || typeof statusType !== 'string' || !statusType.trim()) {
+      throw new Error('Status type is required');
+    }
+
+    const message = buildConversationStatusMessage(
+      text.trim(),
+      statusType.trim(),
+      options,
+    );
+
+    this.state.addMessage(message);
+    this.session.appendToConversation(message);
+
+    return message;
   }
 
   /**

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -48,7 +48,15 @@ export interface ServiceConfig {
 /**
  * Message types
  */
-export type MessageType = 'text' | 'image' | 'video' | 'audio' | 'file' | 'location' | 'interactive'
+export type MessageType =
+  | 'text'
+  | 'image'
+  | 'video'
+  | 'audio'
+  | 'file'
+  | 'location'
+  | 'interactive'
+  | 'conversation_status'
 
 /**
  * Message structure
@@ -59,7 +67,9 @@ export interface Message {
   ID?: string // Uppercase for history compatibility
   type: MessageType
   text?: string
-  
+  /** Semantic category for conversation_status rows (e.g. success, info); host-defined */
+  statusType?: string
+
   // Media fields
   media?: string // Base64 or URL for sending or receiving
   caption?: string // Media caption
@@ -76,6 +86,7 @@ export interface Message {
   
   // Additional data
   metadata?: Record<string, any>
+  persisted?: boolean
 }
 
 /**
@@ -337,6 +348,11 @@ export default class WeniWebchatService {
 
   // Messages
   sendMessage(text: string, options?: any): Promise<void>
+  addConversationStatus(
+    text: string,
+    statusType: string,
+    options?: any
+  ): Message
   addProductToCart(
     props: AddProductToCartProps,
     timeoutMs?: number

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -18,6 +18,7 @@ export const MESSAGE_TYPES = {
   FILE: 'file',
   LOCATION: 'location',
   INTERACTIVE: 'interactive',
+  CONVERSATION_STATUS: 'conversation_status',
   TYPING: 'typing',
 };
 

--- a/src/utils/messageBuilder.js
+++ b/src/utils/messageBuilder.js
@@ -201,6 +201,29 @@ export function buildOrderMessage(productItems, options = {}) {
 }
 
 /**
+ * Builds a local-only conversation status row (not sent over WebSocket).
+ * Host UIs should render using message.type and statusType (e.g. success, info).
+ * Sets persisted so the row survives history merge after WebSocket connect.
+ *
+ * @param {string} text
+ * @param {string} statusType Semantic category defined by the host (success, info, …)
+ * @param {Object} [options]
+ * @returns {Object}
+ */
+export function buildConversationStatusMessage(text, statusType, options = {}) {
+  return {
+    id: options.id || generateMessageId(),
+    type: 'conversation_status',
+    text,
+    statusType,
+    timestamp: options.timestamp || Date.now(),
+    direction: options.direction || 'incoming',
+    persisted: true,
+    metadata: options.metadata || {},
+  };
+}
+
+/**
  * Builds a WebSocket message payload
  * @param {string} type
  * @param {Object} message

--- a/tests/service.test.js
+++ b/tests/service.test.js
@@ -296,6 +296,82 @@ describe('WeniWebchatService', () => {
     });
   });
 
+  describe('addConversationStatus', () => {
+    beforeEach(() => {
+      service = new WeniWebchatService({
+        socketUrl: 'wss://test.example.com',
+        channelUuid: '12345',
+      });
+      service.session.getOrCreate();
+    });
+
+    it('should add conversation status to state and session', () => {
+      const addMessageSpy = jest.spyOn(service.state, 'addMessage');
+      const appendSpy = jest.spyOn(service.session, 'appendToConversation');
+      const enqueueSpy = jest.spyOn(service, 'enqueueMessages');
+
+      const returned = service.addConversationStatus(
+        'Meta Quest 2 added to cart',
+        'success',
+      );
+
+      expect(returned).toEqual(
+        expect.objectContaining({
+          type: 'conversation_status',
+          text: 'Meta Quest 2 added to cart',
+          statusType: 'success',
+          direction: 'incoming',
+          persisted: true,
+        }),
+      );
+      expect(returned.id).toBeDefined();
+      expect(addMessageSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'conversation_status',
+          text: 'Meta Quest 2 added to cart',
+          statusType: 'success',
+        }),
+      );
+      expect(appendSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'conversation_status',
+          statusType: 'success',
+        }),
+      );
+      expect(enqueueSpy).not.toHaveBeenCalled();
+    });
+
+    it('should trim text and statusType', () => {
+      const msg = service.addConversationStatus('  Added  ', '  info  ');
+      expect(msg.text).toBe('Added');
+      expect(msg.statusType).toBe('info');
+    });
+
+    it('should throw when text is missing or empty', () => {
+      expect(() => service.addConversationStatus('', 'success')).toThrow(
+        'Status text is required',
+      );
+      expect(() => service.addConversationStatus('   ', 'success')).toThrow(
+        'Status text is required',
+      );
+      expect(() => service.addConversationStatus(null, 'success')).toThrow(
+        'Status text is required',
+      );
+    });
+
+    it('should throw when statusType is missing or empty', () => {
+      expect(() =>
+        service.addConversationStatus('Added to cart', ''),
+      ).toThrow('Status type is required');
+      expect(() =>
+        service.addConversationStatus('Added to cart', '   '),
+      ).toThrow('Status type is required');
+      expect(() =>
+        service.addConversationStatus('Added to cart', null),
+      ).toThrow('Status type is required');
+    });
+  });
+
   describe('Connection Status', () => {
     beforeEach(() => {
       service = new WeniWebchatService({


### PR DESCRIPTION
## Description

### Type of Change

* * [ ] Bugfix
* * [x] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [x] Tests
* * [ ] Other

### Motivation and Context

Host applications need a way to append **local-only** timeline rows to the chat (for example cart confirmations or system-style notices) without sending them over the WebSocket, while still storing them in the same conversation state/session as other messages.

Semantic **status types** (e.g. `success`, `info`) are preferred over raw colors so each consumer can map types to its own design tokens.

### Summary of Changes

- **`WeniWebchatService.addConversationStatus(text, statusType, options?)`** — Validates non-empty `text` and `statusType`, appends to `StateManager` and `SessionManager` only (no `enqueueMessages` / WebSocket).
- **`buildConversationStatusMessage`** in `messageBuilder.js` — Builds messages with `type: 'conversation_status'`, `text`, `statusType`, timestamps, `direction`, `metadata`, and **`persisted: true`** so they are excluded from the local-ID purge in `_handleWebSocketConnected` after history sync.
- **`MESSAGE_TYPES.CONVERSATION_STATUS`** in `constants.js`.
- **`src/types/index.d.ts`** — `MessageType` / `Message` updates (`statusType`, `persisted`) and service method typing.
- **`tests/service.test.js`** — Coverage for happy path, trimming, validation, no enqueue, and `persisted: true`.