### PR TITLE
[EXPERI-3308] 🐛 Treats Add to Cart Error

### DIFF
--- a/src/core/WebSocketManager.js
+++ b/src/core/WebSocketManager.js
@@ -504,6 +504,23 @@ export default class WebSocketManager extends EventEmitter {
         return;
       }
 
+      if (data.type === 'cart_error') {
+        const itemId = data?.data?.item_id;
+
+        if (itemId && this.pendingAddToCartRequests.has(itemId)) {
+          const pending = this.pendingAddToCartRequests.get(itemId);
+          clearTimeout(pending.timer);
+          this.pendingAddToCartRequests.delete(itemId);
+          const errMsg =
+            typeof data.error === 'string' && data.error.trim()
+              ? data.error.trim()
+              : 'Failed to update cart';
+          pending.reject(new Error(errMsg));
+        }
+
+        return;
+      }
+
       if (
         data.type === 'error' &&
         String(data.error).startsWith('verify contact timeout: ')

--- a/tests/service.test.js
+++ b/tests/service.test.js
@@ -652,6 +652,57 @@ describe('WeniWebchatService', () => {
       await expect(promise).resolves.toEqual({ id: 'product_456' });
     });
 
+    it('should reject when cart_error arrives with matching item_id', async () => {
+      const promise = service.addProductToCart(validProps);
+
+      service.websocket._handleMessage({
+        data: JSON.stringify({
+          type: 'cart_error',
+          error: 'failed to update cart',
+          data: { item_id: 'product_456' },
+        }),
+      });
+
+      await expect(promise).rejects.toThrow('failed to update cart');
+    });
+
+    it('should use fallback message when cart_error has no error string', async () => {
+      const promise = service.addProductToCart(validProps);
+
+      service.websocket._handleMessage({
+        data: JSON.stringify({
+          type: 'cart_error',
+          data: { item_id: 'product_456' },
+        }),
+      });
+
+      await expect(promise).rejects.toThrow('Failed to update cart');
+    });
+
+    it('should ignore duplicate cart_error for same item_id', async () => {
+      const promise = service.addProductToCart(validProps);
+
+      service.websocket._handleMessage({
+        data: JSON.stringify({
+          type: 'cart_error',
+          error: 'failed to update cart',
+          data: { item_id: 'product_456' },
+        }),
+      });
+
+      await expect(promise).rejects.toThrow('failed to update cart');
+
+      expect(() => {
+        service.websocket._handleMessage({
+          data: JSON.stringify({
+            type: 'cart_error',
+            error: 'failed again',
+            data: { item_id: 'product_456' },
+          }),
+        });
+      }).not.toThrow();
+    });
+
     it('should not resolve for a different item_id', async () => {
       jest.useFakeTimers();
 


### PR DESCRIPTION
## Description

### Type of Change

* * [x] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [x] Tests
* * [ ] Other

### Motivation and Context

The server can respond to `add_to_cart` with a `cart_error` WebSocket message (including `data.item_id` and an `error` string) when the cart update fails. Previously only `cart_updated` was handled, so the client promise stayed pending until the timeout. This change aligns error responses with success: pending requests are cleared and promises reject immediately with a meaningful error.

### Summary of Changes

- **`WebSocketManager._handleMessage`** — On `type === 'cart_error'`, if `data.data.item_id` matches an entry in `pendingAddToCartRequests`, the code clears the pending timeout, removes the map entry, and **rejects** the promise with `new Error(trimmed data.error)` or a fallback message when `error` is missing or blank. The handler **returns** so the payload is not emitted as a generic `MESSAGE` (same pattern as `cart_updated`).
- **`tests/service.test.js`** — Tests for rejection on matching `cart_error`, fallback error message, and safe handling of a duplicate `cart_error` after the pending entry is gone.