### PR TITLE
[EXPERI-3353] 🐛 Ignore Orphan Deltas and Finalize from `stream_end` Content

### DIFF
--- a/src/core/MessageProcessor.js
+++ b/src/core/MessageProcessor.js
@@ -258,6 +258,7 @@ export default class MessageProcessor extends EventEmitter {
   /**
    * Processes a delta message
    * Handles sequence-based buffering and reordering
+   * Requires stream_start first; deltas without an active stream are ignored
    * @private
    * @param {Object} raw - { v: string, seq: number }
    */
@@ -269,9 +270,8 @@ export default class MessageProcessor extends EventEmitter {
       return;
     }
 
-    // Create synthetic stream if delta arrives without stream_start
     if (!this.activeStreamId) {
-      this._initializeSyntheticStream(raw);
+      return;
     }
 
     // Handle first delta of the stream
@@ -303,25 +303,6 @@ export default class MessageProcessor extends EventEmitter {
       this.nextExpectedSeq === STREAM_INITIAL_SEQUENCE &&
       seq >= STREAM_INITIAL_SEQUENCE
     );
-  }
-
-  /**
-   * Creates a synthetic stream when delta arrives without stream_start
-   * This handles edge cases where stream_start message is lost
-   * @private
-   * @param {Object} raw
-   */
-  _initializeSyntheticStream(raw) {
-    const messageId = this._getMessageIdFromRaw(raw);
-    this._resetStreamState(messageId);
-    this.streamMessageEmitted = true;
-
-    const timestamp = Date.now();
-    this.streams.set(messageId, { text: '', timestamp });
-
-    const message = this._createStreamingMessage(messageId, timestamp);
-    this.queue.push(message);
-    this._processQueue();
   }
 
   /**
@@ -369,6 +350,25 @@ export default class MessageProcessor extends EventEmitter {
       timestamp,
       direction: 'incoming',
       status: 'streaming',
+    };
+  }
+
+  /**
+   * Finalized incoming text message (e.g. stream_end without prior local stream state)
+   * @private
+   * @param {string} id
+   * @param {string} text
+   * @param {number} timestamp
+   * @returns {Object}
+   */
+  _createDeliveredTextMessage(id, text, timestamp) {
+    return {
+      id,
+      type: 'text',
+      text,
+      timestamp,
+      direction: 'incoming',
+      status: 'delivered',
     };
   }
 
@@ -434,8 +434,9 @@ export default class MessageProcessor extends EventEmitter {
   /**
    * Processes a stream_end message
    * Finalizes the stream and cleans up state
+   * When raw.content is a string, it is the authoritative final text (e.g. after missed stream_start)
    * @private
-   * @param {Object} raw - { type: 'stream_end', id: string }
+   * @param {Object} raw - { type: 'stream_end', id: string, content?: string }
    */
   _processStreamEnd(raw) {
     const messageId = this._getMessageIdFromRaw(raw);
@@ -452,13 +453,28 @@ export default class MessageProcessor extends EventEmitter {
     }
 
     const streamData = this.streams.get(messageId);
-    const finalText = streamData?.text || '';
+    const finalText =
+      typeof raw.content === 'string'
+        ? raw.content
+        : streamData?.text || '';
 
-    this.emit(SERVICE_EVENTS.MESSAGE_UPDATED, messageId, {
-      text: finalText,
-      status: 'delivered',
-      timestamp: Date.now(),
-    });
+    const now = Date.now();
+
+    if (this.streams.has(messageId)) {
+      this.emit(SERVICE_EVENTS.MESSAGE_UPDATED, messageId, {
+        text: finalText,
+        status: 'delivered',
+        timestamp: now,
+      });
+    } else {
+      const message = this._createDeliveredTextMessage(
+        messageId,
+        finalText,
+        now,
+      );
+      this.queue.push(message);
+      this._processQueue();
+    }
 
     this._cleanupStream(messageId);
     this._rememberIncomingText(finalText);

--- a/src/core/MessageProcessor.js
+++ b/src/core/MessageProcessor.js
@@ -454,9 +454,7 @@ export default class MessageProcessor extends EventEmitter {
 
     const streamData = this.streams.get(messageId);
     const finalText =
-      typeof raw.content === 'string'
-        ? raw.content
-        : streamData?.text || '';
+      typeof raw.content === 'string' ? raw.content : streamData?.text || '';
 
     const now = Date.now();
 

--- a/tests/MessageProcessor.test.js
+++ b/tests/MessageProcessor.test.js
@@ -372,31 +372,40 @@ describe('MessageProcessor', () => {
     });
   });
 
-  describe('_initializeSyntheticStream (delta without stream_start)', () => {
-    it('should create synthetic stream when delta arrives without stream_start', () => {
-      const delta = { v: 'Hello', seq: 1, id: 'synthetic-123' };
+  describe('delta without stream_start (orphan deltas)', () => {
+    it('should ignore deltas when no stream_start registered', () => {
+      processor._processDelta({ v: 'Hello', seq: 1, id: 'orphan-1' });
 
-      processor._processDelta(delta);
-
-      expect(processor.activeStreamId).toBe(
-        MESSAGE_ID_PREFIX + 'synthetic-123',
+      expect(processor.activeStreamId).toBeNull();
+      expect(processor.streams.size).toBe(0);
+      expect(mockEmit).not.toHaveBeenCalledWith(
+        SERVICE_EVENTS.MESSAGE_PROCESSED,
+        expect.anything(),
       );
-      expect(processor.streams.has(MESSAGE_ID_PREFIX + 'synthetic-123')).toBe(
-        true,
+      expect(mockEmit).not.toHaveBeenCalledWith(
+        SERVICE_EVENTS.MESSAGE_UPDATED,
+        expect.anything(),
+        expect.anything(),
       );
-      expect(processor.streamMessageEmitted).toBe(true);
     });
 
-    it('should emit streaming message immediately for synthetic stream', () => {
-      const delta = { v: 'Hello', seq: 1, id: 'synthetic-123' };
+    it('should emit delivered message from stream_end with content only', () => {
+      processor._processDelta({ v: 'ignored', seq: 1 });
 
-      processor._processDelta(delta);
+      processor._processStreamEnd({
+        type: 'stream_end',
+        id: 'recovered-b',
+        content: 'Full reply from server',
+      });
 
       expect(mockEmit).toHaveBeenCalledWith(
         SERVICE_EVENTS.MESSAGE_PROCESSED,
         expect.objectContaining({
-          id: MESSAGE_ID_PREFIX + 'synthetic-123',
-          status: 'streaming',
+          id: MESSAGE_ID_PREFIX + 'recovered-b',
+          type: 'text',
+          text: 'Full reply from server',
+          status: 'delivered',
+          direction: 'incoming',
         }),
       );
     });
@@ -418,6 +427,23 @@ describe('MessageProcessor', () => {
         MESSAGE_ID_PREFIX + 'stream-123',
         expect.objectContaining({
           text: 'Hello World',
+          status: 'delivered',
+        }),
+      );
+    });
+
+    it('should use stream_end content over accumulated stream text when provided', () => {
+      processor._processStreamEnd({
+        type: 'stream_end',
+        id: 'stream-123',
+        content: 'Authoritative final text',
+      });
+
+      expect(mockEmit).toHaveBeenCalledWith(
+        SERVICE_EVENTS.MESSAGE_UPDATED,
+        MESSAGE_ID_PREFIX + 'stream-123',
+        expect.objectContaining({
+          text: 'Authoritative final text',
           status: 'delivered',
         }),
       );


### PR DESCRIPTION
## Description

### Type of Change

* * [x] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [x] Tests
* * [ ] Other

### Motivation and Context

After a full page reload, the client can miss `stream_start` while still receiving stream `delta` frames. The previous behavior created a **synthetic** stream from those deltas; when the delta carried no stable id, the processor could emit streaming rows with **`id: null`** and empty text, polluting chat history.

The backend can now send a definitive **`stream_end`** payload that includes the final **`content`** and **`id`**, so the client should **ignore orphan deltas** (no open stream) and **recover the assistant message only from `stream_end`** when there is no local stream state.

### Summary of Changes

- **`MessageProcessor._processDelta`** — If there is no **`activeStreamId`** from a prior **`stream_start`**, deltas are **ignored** (no synthetic stream). Removed **`_initializeSyntheticStream`**.
- **`MessageProcessor._processStreamEnd`** — **`finalText`** uses **`raw.content`** when it is a string (authoritative server body); otherwise falls back to buffered stream text. If a stream entry exists for the message id, emits **`MESSAGE_UPDATED`** as before (server `content` can override accumulated text). If **no** stream entry exists (missed start / skipped deltas), enqueues a delivered incoming text message and emits **`MESSAGE_PROCESSED`** via **`_createDeliveredTextMessage`**, then cleans up and updates duplicate-text memory.
- **`tests/MessageProcessor.test.js`** — Replaced synthetic-stream expectations with orphan-delta tests; added coverage for **`stream_end` + `content`**-only finalization and for **`content`** overriding accumulated stream text.

### Demonstration

<img width="412" height="614" alt="image" src="https://github.com/user-attachments/assets/8c6f2d9d-c09b-4008-91cf-74bc3ecbada1" />