### PR TITLE
🐛 Normalize `media_url` and `caption` for Nested Incoming Chat Messages

### DIFF
--- a/src/core/MessageProcessor.js
+++ b/src/core/MessageProcessor.js
@@ -193,6 +193,12 @@ export default class MessageProcessor extends EventEmitter {
 
     if (raw.message && raw.message.media) {
       message.media = raw.message.media;
+    } else if (raw.message?.media_url) {
+      message.media = raw.message.media_url;
+    }
+
+    if (typeof raw.message?.caption === 'string') {
+      message.caption = raw.message.caption;
     }
 
     if (raw.message && raw.message.quick_replies) {
@@ -509,6 +515,11 @@ export default class MessageProcessor extends EventEmitter {
    * @returns {string}
    */
   _getMessageType(raw) {
+    // Push envelope: type "message" wraps inner content type (file, image, text, …)
+    if (raw.type === 'message' && raw.message?.type) {
+      return raw.message.type;
+    }
+
     if (raw.type) {
       return raw.type;
     }

--- a/tests/MessageProcessor.test.js
+++ b/tests/MessageProcessor.test.js
@@ -806,6 +806,23 @@ describe('MessageProcessor', () => {
       });
     });
 
+    it('should normalize push envelope file message with media_url and caption', () => {
+      const raw = {
+        type: 'message',
+        message: {
+          type: 'file',
+          media_url: 'https://example.com/bucket/file.pdf',
+          caption: 'Privacy policy and terms.',
+        },
+      };
+
+      const normalized = processor._normalizeMessage(raw);
+
+      expect(normalized.type).toBe('file');
+      expect(normalized.media).toBe('https://example.com/bucket/file.pdf');
+      expect(normalized.caption).toBe('Privacy policy and terms.');
+    });
+
     it('should normalize message with quick replies', () => {
       const raw = {
         message: {


### PR DESCRIPTION
## Description

### Type of Change

<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Tests
- [ ] Other

### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Incoming WebSocket payloads often use a top-level envelope (`type: "message"`) with the real content type and attachment fields nested under `message`. The processor previously treated the normalized message `type` as `"message"` and only copied `message.media`, not `media_url`. File and image pushes therefore arrived in the chat without URL or caption, leaving thin placeholder rows instead of a usable attachment.

### Summary of Changes

<!--- Describe your changes in detail -->

- **`_getMessageType`**: When the envelope is `type: "message"` and `message.type` is present, the normalized message now uses the **inner** type (for example `file`, `image`, `video`).
- **`_normalizeMessage`**: Maps **`message.media_url`** to **`media`** (string URL) when `message.media` is absent, and copies **`message.caption`** when it is a string.
- **`tests/MessageProcessor.test.js`**: Adds a case for a push-style envelope with `type: "file"`, `media_url`, and `caption`.