### PR TITLE
🐛 Prevent Stuck Streaming When Deltas or `stream_end` Are Delayed

### DIFF
--- a/src/core/MessageProcessor.js
+++ b/src/core/MessageProcessor.js
@@ -265,7 +265,6 @@ export default class MessageProcessor extends EventEmitter {
     this._clearStreamInactivityTimer();
     this._resetStreamState(messageId);
     this.streams.set(messageId, { text: '', timestamp: Date.now() });
-    this._startStreamInactivityTimer(messageId);
   }
 
   /**
@@ -280,7 +279,7 @@ export default class MessageProcessor extends EventEmitter {
   }
 
   /**
-   * Starts (or schedules) the stream inactivity timer
+   * Starts the stream inactivity timer (first delta only; not started on stream_start)
    * @private
    * @param {string} messageId
    */
@@ -293,7 +292,7 @@ export default class MessageProcessor extends EventEmitter {
   }
 
   /**
-   * Resets the inactivity window (after each delta)
+   * Starts or resets the inactivity window from the first delta onward
    * @private
    * @param {string} messageId
    */

--- a/src/core/MessageProcessor.js
+++ b/src/core/MessageProcessor.js
@@ -6,6 +6,7 @@ import {
   SERVICE_EVENTS,
   MESSAGE_ID_PREFIX,
   STREAM_INITIAL_SEQUENCE,
+  STREAM_START_TIMEOUT_MS,
 } from '../utils/constants';
 
 /**
@@ -39,6 +40,8 @@ export default class MessageProcessor extends EventEmitter {
     this.isThinkingActive = false;
     this.streams = new Map();
     this.recentIncomingTexts = [];
+    this.streamInactivityTimer = null;
+    this.timedOutStreamIds = new Set();
 
     // Streaming state
     this._resetStreamState();
@@ -169,6 +172,7 @@ export default class MessageProcessor extends EventEmitter {
   clearQueue() {
     this.queue = [];
     this.isProcessing = false;
+    this._clearStreamInactivityTimer();
   }
 
   /**
@@ -257,8 +261,76 @@ export default class MessageProcessor extends EventEmitter {
       return;
     }
 
+    this.timedOutStreamIds.delete(messageId);
+    this._clearStreamInactivityTimer();
     this._resetStreamState(messageId);
     this.streams.set(messageId, { text: '', timestamp: Date.now() });
+    this._startStreamInactivityTimer(messageId);
+  }
+
+  /**
+   * Clears the stream inactivity timer
+   * @private
+   */
+  _clearStreamInactivityTimer() {
+    if (this.streamInactivityTimer) {
+      clearTimeout(this.streamInactivityTimer);
+      this.streamInactivityTimer = null;
+    }
+  }
+
+  /**
+   * Starts (or schedules) the stream inactivity timer
+   * @private
+   * @param {string} messageId
+   */
+  _startStreamInactivityTimer(messageId) {
+    this._clearStreamInactivityTimer();
+    this.streamInactivityTimer = setTimeout(() => {
+      this.streamInactivityTimer = null;
+      this._handleStreamInactivityTimeout(messageId);
+    }, STREAM_START_TIMEOUT_MS);
+  }
+
+  /**
+   * Resets the inactivity window (after each delta)
+   * @private
+   * @param {string} messageId
+   */
+  _restartStreamInactivityTimer(messageId) {
+    if (!messageId) {
+      return;
+    }
+    this._startStreamInactivityTimer(messageId);
+  }
+
+  /**
+   * Finalizes the stream after inactivity timeout (same outcome as stream_end without content)
+   * @private
+   * @param {string} messageId
+   */
+  _handleStreamInactivityTimeout(messageId) {
+    if (this.activeStreamId !== messageId) {
+      return;
+    }
+
+    this._stopTyping();
+
+    const streamData = this.streams.get(messageId);
+    const finalText = streamData?.text ?? '';
+    const now = Date.now();
+
+    if (this.streams.has(messageId)) {
+      this.emit(SERVICE_EVENTS.MESSAGE_UPDATED, messageId, {
+        text: finalText,
+        status: 'delivered',
+        timestamp: now,
+      });
+    }
+
+    this.timedOutStreamIds.add(messageId);
+    this._rememberIncomingText(finalText);
+    this._cleanupStream(messageId);
   }
 
   /**
@@ -279,6 +351,8 @@ export default class MessageProcessor extends EventEmitter {
     if (!this.activeStreamId) {
       return;
     }
+
+    this._restartStreamInactivityTimer(this.activeStreamId);
 
     // Handle first delta of the stream
     if (this._isFirstDelta(seq)) {
@@ -454,6 +528,12 @@ export default class MessageProcessor extends EventEmitter {
       return;
     }
 
+    if (this.timedOutStreamIds.has(messageId)) {
+      return;
+    }
+
+    this._clearStreamInactivityTimer();
+
     if (this.isTypingActive || this.isThinkingActive) {
       this._stopTyping();
     }
@@ -490,6 +570,10 @@ export default class MessageProcessor extends EventEmitter {
    * @param {string} messageId
    */
   _cleanupStream(messageId) {
+    if (this.activeStreamId === messageId) {
+      this._clearStreamInactivityTimer();
+    }
+
     this.streams.delete(messageId);
 
     if (this.activeStreamId === messageId) {

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -294,3 +294,6 @@ export const SERVICE_NAME = '@weni/webchat-service';
 export const MESSAGE_ID_PREFIX = 'msg_';
 
 export const STREAM_INITIAL_SEQUENCE = 1;
+
+/** Max idle time after stream_start or last delta before auto-finalizing the stream */
+export const STREAM_START_TIMEOUT_MS = 2000;

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -295,5 +295,5 @@ export const MESSAGE_ID_PREFIX = 'msg_';
 
 export const STREAM_INITIAL_SEQUENCE = 1;
 
-/** Max idle time after stream_start or last delta before auto-finalizing the stream */
+/** Max idle time after the first delta (and between deltas) before auto-finalizing the stream */
 export const STREAM_START_TIMEOUT_MS = 2000;

--- a/tests/MessageProcessor.test.js
+++ b/tests/MessageProcessor.test.js
@@ -3,6 +3,7 @@ import {
   SERVICE_EVENTS,
   MESSAGE_ID_PREFIX,
   STREAM_INITIAL_SEQUENCE,
+  STREAM_START_TIMEOUT_MS,
   DEFAULTS,
 } from '../src/utils/constants';
 
@@ -408,6 +409,134 @@ describe('MessageProcessor', () => {
           direction: 'incoming',
         }),
       );
+    });
+  });
+
+  describe('stream inactivity timeout', () => {
+    const streamId = 'timeout-test';
+    const prefixedId = MESSAGE_ID_PREFIX + streamId;
+
+    it('should finalize with empty text when no delta arrives within 2s', () => {
+      processor._processStreamStart({ type: 'stream_start', id: streamId });
+
+      jest.advanceTimersByTime(STREAM_START_TIMEOUT_MS + 1);
+
+      expect(mockEmit).toHaveBeenCalledWith(
+        SERVICE_EVENTS.MESSAGE_UPDATED,
+        prefixedId,
+        expect.objectContaining({
+          text: '',
+          status: 'delivered',
+        }),
+      );
+      expect(processor.activeStreamId).toBeNull();
+      expect(processor.streams.has(prefixedId)).toBe(false);
+      expect(processor.timedOutStreamIds.has(prefixedId)).toBe(true);
+    });
+
+    it('should ignore deltas after inactivity timeout', () => {
+      processor._processStreamStart({ type: 'stream_start', id: streamId });
+      jest.advanceTimersByTime(STREAM_START_TIMEOUT_MS + 1);
+
+      mockEmit.mockClear();
+
+      processor._processDelta({ v: 'late', seq: 1 });
+
+      expect(mockEmit).not.toHaveBeenCalledWith(
+        SERVICE_EVENTS.MESSAGE_UPDATED,
+        prefixedId,
+        expect.anything(),
+      );
+      expect(mockEmit).not.toHaveBeenCalledWith(
+        SERVICE_EVENTS.MESSAGE_PROCESSED,
+        expect.anything(),
+      );
+    });
+
+    it('should ignore stream_end after inactivity timeout', () => {
+      processor._processStreamStart({ type: 'stream_start', id: streamId });
+      jest.advanceTimersByTime(STREAM_START_TIMEOUT_MS + 1);
+
+      mockEmit.mockClear();
+
+      processor._processStreamEnd({
+        type: 'stream_end',
+        id: streamId,
+        content: 'late content',
+      });
+
+      expect(mockEmit).not.toHaveBeenCalledWith(
+        SERVICE_EVENTS.MESSAGE_PROCESSED,
+        expect.anything(),
+      );
+      expect(mockEmit).not.toHaveBeenCalledWith(
+        SERVICE_EVENTS.MESSAGE_UPDATED,
+        prefixedId,
+        expect.objectContaining({ text: 'late content' }),
+      );
+    });
+
+    it('should restart idle window on each delta', () => {
+      processor._processStreamStart({ type: 'stream_start', id: streamId });
+
+      jest.advanceTimersByTime(1500);
+      processor._processDelta({ v: 'Hi', seq: 1 });
+
+      jest.advanceTimersByTime(1500);
+      expect(processor.activeStreamId).toBe(prefixedId);
+
+      jest.advanceTimersByTime(STREAM_START_TIMEOUT_MS + 1);
+
+      expect(mockEmit).toHaveBeenCalledWith(
+        SERVICE_EVENTS.MESSAGE_UPDATED,
+        prefixedId,
+        expect.objectContaining({
+          text: 'Hi',
+          status: 'delivered',
+        }),
+      );
+      expect(processor.activeStreamId).toBeNull();
+    });
+
+    it('should keep stream alive when deltas arrive within 2s gaps', () => {
+      processor._processStreamStart({ type: 'stream_start', id: streamId });
+
+      jest.advanceTimersByTime(1000);
+      processor._processDelta({ v: 'A', seq: 1 });
+
+      jest.advanceTimersByTime(1500);
+      processor._processDelta({ v: 'B', seq: 2 });
+
+      jest.advanceTimersByTime(STREAM_START_TIMEOUT_MS - 1);
+      expect(processor.activeStreamId).toBe(prefixedId);
+
+      jest.advanceTimersByTime(2);
+      expect(processor.activeStreamId).toBeNull();
+    });
+
+    it('should clear inactivity timer on stream_end without timeout finalize', () => {
+      processor._processStreamStart({ type: 'stream_start', id: streamId });
+
+      jest.advanceTimersByTime(500);
+      processor._processStreamEnd({ type: 'stream_end', id: streamId });
+
+      const deliveredCalls = mockEmit.mock.calls.filter(
+        ([event, id, payload]) =>
+          event === SERVICE_EVENTS.MESSAGE_UPDATED &&
+          id === prefixedId &&
+          payload?.status === 'delivered',
+      );
+      expect(deliveredCalls).toHaveLength(1);
+
+      mockEmit.mockClear();
+      jest.advanceTimersByTime(3000);
+
+      expect(mockEmit).not.toHaveBeenCalledWith(
+        SERVICE_EVENTS.MESSAGE_UPDATED,
+        prefixedId,
+        expect.anything(),
+      );
+      expect(processor.timedOutStreamIds.has(prefixedId)).toBe(false);
     });
   });
 

--- a/tests/MessageProcessor.test.js
+++ b/tests/MessageProcessor.test.js
@@ -416,8 +416,24 @@ describe('MessageProcessor', () => {
     const streamId = 'timeout-test';
     const prefixedId = MESSAGE_ID_PREFIX + streamId;
 
-    it('should finalize with empty text when no delta arrives within 2s', () => {
+    it('should not timeout while waiting for the first delta after stream_start', () => {
       processor._processStreamStart({ type: 'stream_start', id: streamId });
+
+      jest.advanceTimersByTime(10000);
+
+      expect(processor.activeStreamId).toBe(prefixedId);
+      expect(processor.streams.has(prefixedId)).toBe(true);
+      expect(processor.timedOutStreamIds.has(prefixedId)).toBe(false);
+      expect(mockEmit).not.toHaveBeenCalledWith(
+        SERVICE_EVENTS.MESSAGE_UPDATED,
+        prefixedId,
+        expect.objectContaining({ status: 'delivered' }),
+      );
+    });
+
+    it('should finalize when idle for 2s after the first delta', () => {
+      processor._processStreamStart({ type: 'stream_start', id: streamId });
+      processor._processDelta({ v: 'Hi', seq: 1 });
 
       jest.advanceTimersByTime(STREAM_START_TIMEOUT_MS + 1);
 
@@ -425,22 +441,22 @@ describe('MessageProcessor', () => {
         SERVICE_EVENTS.MESSAGE_UPDATED,
         prefixedId,
         expect.objectContaining({
-          text: '',
+          text: 'Hi',
           status: 'delivered',
         }),
       );
       expect(processor.activeStreamId).toBeNull();
-      expect(processor.streams.has(prefixedId)).toBe(false);
       expect(processor.timedOutStreamIds.has(prefixedId)).toBe(true);
     });
 
     it('should ignore deltas after inactivity timeout', () => {
       processor._processStreamStart({ type: 'stream_start', id: streamId });
+      processor._processDelta({ v: 'Hi', seq: 1 });
       jest.advanceTimersByTime(STREAM_START_TIMEOUT_MS + 1);
 
       mockEmit.mockClear();
 
-      processor._processDelta({ v: 'late', seq: 1 });
+      processor._processDelta({ v: 'late', seq: 2 });
 
       expect(mockEmit).not.toHaveBeenCalledWith(
         SERVICE_EVENTS.MESSAGE_UPDATED,
@@ -455,6 +471,7 @@ describe('MessageProcessor', () => {
 
     it('should ignore stream_end after inactivity timeout', () => {
       processor._processStreamStart({ type: 'stream_start', id: streamId });
+      processor._processDelta({ v: 'Hi', seq: 1 });
       jest.advanceTimersByTime(STREAM_START_TIMEOUT_MS + 1);
 
       mockEmit.mockClear();
@@ -479,7 +496,7 @@ describe('MessageProcessor', () => {
     it('should restart idle window on each delta', () => {
       processor._processStreamStart({ type: 'stream_start', id: streamId });
 
-      jest.advanceTimersByTime(1500);
+      jest.advanceTimersByTime(5000);
       processor._processDelta({ v: 'Hi', seq: 1 });
 
       jest.advanceTimersByTime(1500);


### PR DESCRIPTION
## Description

### Type of Change

<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->

- [x] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Tests
- [ ] Other

### Motivation and Context

After `stream_start`, there is often a noticeable delay before the first delta arrives. Starting the inactivity timer on `stream_start` caused **false stream closures** while the assistant was still preparing the reply. The idle window must apply only **after streaming content begins** (first delta), then reset on each subsequent delta, so the gap between `stream_start` and the first delta does not count toward the timeout.

### Summary of Changes

- **`STREAM_START_TIMEOUT_MS` (2000)** in [`src/utils/constants.js`](src/utils/constants.js) — idle time measured from the **first delta** and between deltas, not from `stream_start`.
- **`MessageProcessor`**: no inactivity timer on `stream_start`; **`_restartStreamInactivityTimer`** on each accepted delta (starts the timer on the first delta). On timeout, finalize like `stream_end`, add id to **`timedOutStreamIds`**, ignore late deltas and `stream_end` for that id.
- **Unit tests** updated in [`tests/MessageProcessor.test.js`](tests/MessageProcessor.test.js): long wait before first delta does **not** close the stream; timeout applies only after deltas have started.

```mermaid
sequenceDiagram
  participant WS as WebSocket
  participant MP as MessageProcessor
  WS->>MP: stream_start id
  Note over MP: no inactivity timer yet
  WS->>MP: first delta
  MP->>MP: start 2s inactivity timer
  loop each later delta within idle window
    WS->>MP: delta
    MP->>MP: restart 2s timer
  end
  alt stream_end before idle expires
    WS->>MP: stream_end
    MP->>MP: clear timer
    MP->>MP: normal finalize
  else 2s idle after last delta
    MP->>MP: finalize as stream_end
    MP->>MP: timedOutStreamIds.add id
    WS->>MP: late delta or stream_end
    MP->>MP: ignore
  end