### PR TITLE
✨ Support Interactive Product Carousel Messages From WebSocket

### DIFF
--- a/src/core/MessageProcessor.js
+++ b/src/core/MessageProcessor.js
@@ -233,6 +233,13 @@ export default class MessageProcessor extends EventEmitter {
       };
     }
 
+    if (interactive?.type === 'product_carousel') {
+      message.product_carousel = {
+        text: raw.message.text,
+        product_items: interactive.action?.product_items,
+      };
+    }
+
     if (interactive?.header) {
       message.header = interactive.header.text;
     }

--- a/src/modules/HistoryManager.js
+++ b/src/modules/HistoryManager.js
@@ -164,6 +164,13 @@ export default class HistoryManager extends EventEmitter {
             sections: interactive.action?.sections,
           };
         }
+
+        if (interactive?.type === 'product_carousel') {
+          message.product_carousel = {
+            text: message.text,
+            product_items: interactive.action?.product_items,
+          };
+        }
       }
 
       if (item.message?.type === 'order') {

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -82,6 +82,17 @@ export interface Message {
   
   // Interactive elements
   quick_replies?: QuickReply[]
+  header?: string
+  footer?: string
+  product_list?: {
+    text?: string
+    buttonText?: string
+    sections?: unknown[]
+  }
+  product_carousel?: {
+    text?: string
+    product_items?: unknown[]
+  }
 
   
   // Additional data

--- a/tests/HistoryManager.test.js
+++ b/tests/HistoryManager.test.js
@@ -693,6 +693,49 @@ describe('HistoryManager', () => {
         });
       });
 
+      it('should normalize interactive message with product_carousel type', () => {
+        const productItems = [
+          {
+            product_retailer_id: '5371#1',
+            name: 'Blusa 2',
+            price: '10.00',
+            image: 'https://imgur.com/DjO2QIa.jpg',
+          },
+        ];
+
+        const rawHistory = [
+          {
+            ID: 'msg-interactive-carousel',
+            timestamp: 1700000000,
+            direction: 'in',
+            message: {
+              type: 'interactive',
+              text: 'Oie',
+              interactive: {
+                type: 'product_carousel',
+                header: { type: 'text', text: 'Coleção Workshirt' },
+                footer: { text: 'Footer copy' },
+                action: { product_items: productItems },
+              },
+            },
+          },
+        ];
+
+        const result = historyManager.processHistory(rawHistory);
+
+        expect(result[0]).toMatchObject({
+          type: 'interactive',
+          text: 'Oie',
+          header: 'Coleção Workshirt',
+          footer: 'Footer copy',
+        });
+        expect(result[0].product_carousel).toEqual({
+          text: 'Oie',
+          product_items: productItems,
+        });
+        expect(result[0].product_list).toBeUndefined();
+      });
+
       it('should normalize interactive message with header, footer and product_list', () => {
         const rawHistory = [
           {
@@ -759,6 +802,7 @@ describe('HistoryManager', () => {
         const result = historyManager.processHistory(rawHistory);
 
         expect(result[0].product_list).toBeUndefined();
+        expect(result[0].product_carousel).toBeUndefined();
       });
 
       it('should not set header/footer when not present in interactive', () => {

--- a/tests/MessageProcessor.test.js
+++ b/tests/MessageProcessor.test.js
@@ -1425,6 +1425,61 @@ describe('MessageProcessor', () => {
       });
     });
 
+    it('should normalize push envelope interactive product_carousel', () => {
+      const productItems = [
+        {
+          product_retailer_id: '5371#1',
+          name: 'Blusa 2',
+          price: '10.00',
+          currency: '',
+          image: 'https://imgur.com/DjO2QIa.jpg',
+          description: 'aaaa',
+          seller_id: '1',
+          product_url: 'https://weni.ai',
+        },
+        {
+          product_retailer_id: '10#bravtexgrocerystore02',
+          name: 'Blusa 1',
+          price: '10.90',
+          currency: '',
+          image: 'https://imgur.com/DjO2QIa.jpg',
+          description: 'bbbbb',
+          seller_id: '1',
+          product_url: 'https://weni.ai',
+        },
+      ];
+
+      const raw = {
+        type: 'message',
+        message: {
+          type: 'interactive',
+          text: 'Oie',
+          interactive: {
+            type: 'product_carousel',
+            header: { type: 'text', text: 'Coleção Workshirt' },
+            footer: {
+              text: 'Todas com proteção UV e detalhes exclusivos',
+            },
+            action: { product_items: productItems },
+          },
+        },
+      };
+
+      const normalized = processor._normalizeMessage(raw);
+
+      expect(normalized.type).toBe('interactive');
+      expect(normalized.text).toBe('Oie');
+      expect(normalized.header).toBe('Coleção Workshirt');
+      expect(normalized.footer).toBe(
+        'Todas com proteção UV e detalhes exclusivos',
+      );
+      expect(normalized.product_carousel).toEqual({
+        text: 'Oie',
+        product_items: productItems,
+      });
+      expect(normalized.product_list).toBeUndefined();
+    });
+
     it('should normalize message with interactive header', () => {
       const raw = {
         message: {
@@ -1506,6 +1561,7 @@ describe('MessageProcessor', () => {
       const normalized = processor._normalizeMessage(raw);
 
       expect(normalized.product_list).toBeUndefined();
+      expect(normalized.product_carousel).toBeUndefined();
     });
 
     it('should not set header/footer when interactive has no header/footer', () => {


### PR DESCRIPTION
## Description

### Type of Change

<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Tests
- [ ] Other

### Motivation and Context

The backend can send interactive messages with `interactive.type: "product_carousel"` inside the standard push envelope (`type: "message"`, inner `message.type: "interactive"`). The service already normalizes `product_list`, but carousel payloads were not mapped, so host apps could not render product cards from live socket messages or history.

### Summary of Changes

- **`MessageProcessor._normalizeMessage`**: When `interactive.type === 'product_carousel'`, maps `message.text`, `header`, `footer`, and **`product_carousel`** with `{ text, product_items }` from `interactive.action.product_items` (same header/footer pattern as `product_list`).
- **`HistoryManager.processHistory`**: Same normalization for historical interactive carousel messages.
- **`src/types/index.d.ts`**: Optional `product_carousel`, `product_list`, `header`, and `footer` on `Message`.
- **Tests** in `tests/MessageProcessor.test.js` and `tests/HistoryManager.test.js` using a push-style payload with multiple `product_items`.