### PR TITLE
feat: Add productPath to conversation starters payload

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@weni/webchat-service",
-  "version": "1.12.0",
+  "version": "1.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@weni/webchat-service",
-      "version": "1.12.0",
+      "version": "1.13.0",
       "license": "ISC",
       "dependencies": {
         "eventemitter3": "^5.0.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@weni/webchat-service",
-  "version": "1.12.0",
+  "version": "1.13.0",
   "description": "Framework-agnostic JavaScript library for Weni WebChat integration",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",

--- a/src/index.js
+++ b/src/index.js
@@ -553,8 +553,8 @@ export default class WeniWebchatService extends EventEmitter {
       throw new Error('WebSocket not connected');
     }
 
-    this._latestStartersFingerprint =
-      productData.account + ':' + productData.linkText;
+    const pathKey = productData.productPath || productData.linkText;
+    this._latestStartersFingerprint = `${productData.account}:${pathKey}`;
 
     const payload = buildStartersRequest(
       this.session.getSessionId(),

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -160,6 +160,7 @@ export interface WebSocketMessage {
 export interface StartersData {
   account: string
   linkText: string
+  productPath?: string
   productName?: string
   description?: string
   brand?: string

--- a/src/utils/messageBuilder.js
+++ b/src/utils/messageBuilder.js
@@ -256,6 +256,7 @@ export function buildStartersRequest(sessionId, productData) {
     linkText: productData.linkText,
   };
 
+  if (productData.productPath) data.productPath = productData.productPath;
   if (productData.productName) data.productName = productData.productName;
   if (productData.description) data.description = productData.description;
   if (productData.brand) data.brand = productData.brand;

--- a/tests/starters.test.js
+++ b/tests/starters.test.js
@@ -107,10 +107,20 @@ describe('buildStartersRequest', () => {
   it('should omit optional fields when not provided', () => {
     const payload = buildStartersRequest('session-123', VALID_PRODUCT_DATA);
 
+    expect(payload.data).not.toHaveProperty('productPath');
     expect(payload.data).not.toHaveProperty('productName');
     expect(payload.data).not.toHaveProperty('description');
     expect(payload.data).not.toHaveProperty('brand');
     expect(payload.data).not.toHaveProperty('attributes');
+  });
+
+  it('should include productPath when provided', () => {
+    const payload = buildStartersRequest('session-123', {
+      ...VALID_PRODUCT_DATA,
+      productPath: '/en/ipad-10th-gen/p',
+    });
+
+    expect(payload.data.productPath).toBe('/en/ipad-10th-gen/p');
   });
 });
 
@@ -277,6 +287,24 @@ describe('WeniWebchatService - getStarters', () => {
 
       service.getStarters({ account: 'b', linkText: 'product-b' });
       expect(service._latestStartersFingerprint).toBe('b:product-b');
+    });
+
+    it('should use productPath in fingerprint when provided', () => {
+      makeConnected(service);
+
+      service.getStarters({
+        account: 'store',
+        linkText: 'ipad',
+        productPath: '/en/ipad/p',
+      });
+      expect(service._latestStartersFingerprint).toBe('store:/en/ipad/p');
+    });
+
+    it('should fall back to linkText in fingerprint when productPath is absent', () => {
+      makeConnected(service);
+
+      service.getStarters({ account: 'store', linkText: 'ipad' });
+      expect(service._latestStartersFingerprint).toBe('store:ipad');
     });
 
     it('should clear fingerprint after emitting starters:received', () => {


### PR DESCRIPTION
## What
Adds optional `productPath` support to the PDP conversation starters bridge in `@weni/webchat-service`. The field is forwarded in `get_pdp_starters` WebSocket payloads, and request fingerprinting now prefers `productPath` over `linkText`.

## Why
VTEX stores with locale-prefixed URLs (e.g. `/en/product/p` vs `/pt/product/p`) share the same product slug (`linkText`). Using only the slug for fingerprinting caused stale or incorrect starters when navigating between language paths. Sending the full pathname lets downstream services cache and dedupe per locale while remaining backward compatible with clients that omit `productPath`.

## Test plan
- [x] `npx jest tests/starters.test.js` (Node 24)
- [x] Payload includes `productPath` when provided
- [x] Fingerprint uses `account:productPath` when present, falls back to `account:linkText`
- [x] Existing starters behavior unchanged when `productPath` is absent


Made with [Cursor](https://cursor.com)